### PR TITLE
Replaced Unit with ()

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,8 @@ license = "MPL-2.0"
 [dependencies]
 dusk-bytes = "0.1"
 dusk-poseidon = { version = "0.28" }
-dusk-merkle = { version = "0.2", features = ["rkyv-impl", "poseidon", "zk", "size_32"] }
+#dusk-merkle = { version = "0.2", features = ["rkyv-impl", "poseidon", "zk", "size_32"] }
+dusk-merkle = { path = "../merkle", features = ["rkyv-impl", "poseidon", "zk", "size_32"] }
 dusk-plonk = { version = "0.13", default-features = false, features = ["alloc"] }
 dusk-bls12_381 = { version = "0.11", default-features = false }
 dusk-jubjub = { version = "0.12", default-features = false }

--- a/src/license.rs
+++ b/src/license.rs
@@ -213,8 +213,8 @@ pub struct LicenseProverParameters<const DEPTH: usize, const ARITY: usize> {
     pub com_1: JubJubExtended, // Pedersen Commitment 1
     pub com_2: JubJubExtended, // Pedersen Commitment 2
 
-    pub session_hash: BlsScalar,                   // hash of the session
-    pub sig_session_hash: dusk_schnorr::Proof,     // signature of the session_hash
+    pub session_hash: BlsScalar,                 // hash of the session
+    pub sig_session_hash: dusk_schnorr::Proof,   // signature of the session_hash
     pub merkle_proof: Opening<(), DEPTH, ARITY>, // Merkle proof for the Proof of Validity
 }
 

--- a/src/license.rs
+++ b/src/license.rs
@@ -17,7 +17,7 @@ use rand_core::{CryptoRng, RngCore};
 
 use dusk_plonk::prelude::*;
 
-use crate::state::{PoseidonItem, State, Unit};
+use crate::state::{PoseidonItem, State};
 
 pub struct Request {
     rsa: StealthAddress,   // request stealth address
@@ -215,7 +215,7 @@ pub struct LicenseProverParameters<const DEPTH: usize, const ARITY: usize> {
 
     pub session_hash: BlsScalar,                   // hash of the session
     pub sig_session_hash: dusk_schnorr::Proof,     // signature of the session_hash
-    pub merkle_proof: Opening<Unit, DEPTH, ARITY>, // Merkle proof for the Proof of Validity
+    pub merkle_proof: Opening<(), DEPTH, ARITY>, // Merkle proof for the Proof of Validity
 }
 
 impl<const DEPTH: usize, const ARITY: usize> Default for LicenseProverParameters<DEPTH, ARITY> {
@@ -223,7 +223,7 @@ impl<const DEPTH: usize, const ARITY: usize> Default for LicenseProverParameters
         let mut tree = Tree::new();
         let item = PoseidonItem {
             hash: BlsScalar::zero(),
-            data: Unit,
+            data: (),
         };
         tree.insert(0, item);
         let merkle_proof = tree.opening(0).expect("There is a leaf at position 0");

--- a/src/state.rs
+++ b/src/state.rs
@@ -5,7 +5,6 @@
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
 use dusk_merkle::poseidon::{Item, Opening, Tree};
-use dusk_merkle::Aggregate;
 use dusk_pki::ViewKey;
 use dusk_plonk::prelude::*;
 use dusk_poseidon::sponge;
@@ -13,25 +12,10 @@ use std::collections::BTreeMap;
 
 use crate::license::License;
 
-#[derive(Default, Debug, Clone, Copy)]
-pub struct Unit;
-
-impl<const H: usize, const A: usize> Aggregate<H, A> for Unit {
-    const EMPTY_SUBTREES: [Self; H] = [Unit; H];
-
-    fn aggregate<'a, I>(_items: I) -> Self
-    where
-        Self: 'a,
-        I: Iterator<Item = &'a Self>,
-    {
-        Unit
-    }
-}
-
-pub type PoseidonItem = Item<Unit>;
+pub type PoseidonItem = Item<()>;
 
 pub struct State<const DEPTH: usize, const ARITY: usize> {
-    tree: Tree<Unit, DEPTH, ARITY>,
+    tree: Tree<(), DEPTH, ARITY>,
     licenses: BTreeMap<u64, License>,
 }
 
@@ -44,7 +28,7 @@ impl<const DEPTH: usize, const ARITY: usize> Default for State<DEPTH, ARITY> {
 impl<const DEPTH: usize, const ARITY: usize> State<DEPTH, ARITY> {
     pub fn new() -> State<DEPTH, ARITY> {
         State {
-            tree: Tree::<Unit, DEPTH, ARITY>::new(),
+            tree: Tree::<(), DEPTH, ARITY>::new(),
             licenses: BTreeMap::new(),
         }
     }
@@ -53,7 +37,7 @@ impl<const DEPTH: usize, const ARITY: usize> State<DEPTH, ARITY> {
 
         let item = PoseidonItem {
             hash: sponge::hash(&[lpk.get_x(), lpk.get_y()]),
-            data: Unit,
+            data: (),
         };
 
         lic.pos = self.licenses.len() as u64;
@@ -69,7 +53,7 @@ impl<const DEPTH: usize, const ARITY: usize> State<DEPTH, ARITY> {
             .collect()
     }
 
-    pub fn get_merkle_proof(&self, lic: &License) -> Opening<Unit, DEPTH, ARITY> {
+    pub fn get_merkle_proof(&self, lic: &License) -> Opening<(), DEPTH, ARITY> {
         self.tree
             .opening(lic.pos)
             .expect("Tree was read successfully")


### PR DESCRIPTION
Replaced Unit with () as () is now supported by dusk-merkle and implements Aggregate.
This PR needs to be merged only after its dusk-merkle dependency is corrected to a dusk-merkle upcoming release,
hence for now this is a draft PR only.