### PR TITLE
Rkyv derivation for the Request struct

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,16 +10,17 @@ license = "MPL-2.0"
 
 [dependencies]
 dusk-bytes = "0.1"
-dusk-poseidon = { version = "0.28" }
+dusk-poseidon = { version = "0.28", default-features = false, features = ["rkyv-impl", "alloc"] }
 dusk-merkle = { version = "0.4", features = ["rkyv-impl", "poseidon", "zk", "size_32"] }
-dusk-plonk = { version = "0.13", default-features = false, features = ["alloc"] }
+dusk-plonk = { version = "0.13", default-features = false, features = ["rkyv-impl", "alloc"] }
 dusk-bls12_381 = { version = "0.11", default-features = false }
 dusk-jubjub = { version = "0.12", default-features = false }
-dusk-pki = { version = "0.11", default-features = false}
-dusk-schnorr = { version = "0.12" }
+dusk-pki = { version = "0.11", default-features = false, features = ["rkyv-impl"] }
+dusk-schnorr = { version = "0.12", default-features = false, features = ["rkyv-impl", "alloc"] }
 rand_core = { version = "0.6", default-features=false, features = ["getrandom"] }
 nstack = { version = "0.16" }
-rkyv = { version = "0.7", optional = true, default-features = false }
+rkyv = { version = "0.7", default-features = false }
+bytecheck = { version = "0.6", default-features = false }
 
 [dev-dependencies]
 criterion = "0.3"
@@ -28,3 +29,7 @@ lazy_static = "1.4"
 [[bench]]
 name = "citadel"
 harness = false
+
+[features]
+rkyv-impl = []
+default=["rkyv-impl"]

--- a/src/license.rs
+++ b/src/license.rs
@@ -15,9 +15,16 @@ use dusk_poseidon::cipher::PoseidonCipher;
 use dusk_poseidon::sponge;
 use dusk_schnorr::Signature;
 use rand_core::{CryptoRng, RngCore};
+#[cfg(feature = "rkyv-impl")]
+use rkyv::{Archive, Deserialize, Serialize};
 
 use dusk_plonk::prelude::*;
 
+#[cfg_attr(
+    feature = "rkyv-impl",
+    derive(Archive, Serialize, Deserialize),
+    archive_attr(derive(bytecheck::CheckBytes))
+)]
 pub struct Request {
     rsa: StealthAddress,   // request stealth address
     enc_1: PoseidonCipher, // encryption of the license stealth address and k_lic


### PR DESCRIPTION
Added Rkyv derivation for the Request struct,
which is needed for the Request blockchain submitting/scanning utility.