### PR TITLE
Reuse test code to eliminate repetition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add Utils implementation
 
+### Changed
+
+- Updated poseidon_merkle from 0.2 to 0.2.1-rc.0
+
 ## [0.4.0] - 2023-06-28
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add Utils implementation
+
 ## [0.4.0] - 2023-06-28
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license = "MPL-2.0"
 [dependencies]
 dusk-bytes = "0.1"
 dusk-poseidon = { version = "0.30", default-features = false, features = ["rkyv-impl", "alloc"] }
-poseidon-merkle = { version = "0.2", features = ["rkyv-impl", "zk", "size_32"] }
+poseidon-merkle = { version = "0.2.1-rc.0", features = ["rkyv-impl", "zk", "size_32"] }
 dusk-plonk = { version = "0.14", default-features = false, features = ["rkyv-impl", "alloc"] }
 dusk-bls12_381 = { version = "0.11", default-features = false }
 dusk-jubjub = { version = "0.12", default-features = false }

--- a/benches/citadel.rs
+++ b/benches/citadel.rs
@@ -8,9 +8,7 @@ use dusk_pki::{PublicSpendKey, SecretSpendKey};
 use dusk_plonk::prelude::*;
 
 use zk_citadel::gadgets;
-use zk_citadel::license::{
-    CitadelProverParameters, SessionCookie, ShelterProverParameters,
-};
+use zk_citadel::license::{CitadelProverParameters, SessionCookie, ShelterProverParameters};
 
 use criterion::{criterion_group, criterion_main, Criterion};
 use rand_core::OsRng;
@@ -123,7 +121,7 @@ fn shelter_benchmark(crit: &mut Criterion) {
         KEYS.ssk,
         KEYS.psk,
         KEYS.ssk_lp,
-        KEYS.psk_lp
+        KEYS.psk_lp,
     );
 
     let c = JubJubScalar::from(CHALLENGE);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,3 +6,4 @@
 
 pub mod gadgets;
 pub mod license;
+pub mod utils;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,86 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+use crate::license::{CitadelProverParameters, License, Request, SessionCookie};
+use dusk_jubjub::{JubJubAffine, JubJubScalar, GENERATOR_EXTENDED};
+use dusk_pki::{PublicSpendKey, SecretSpendKey};
+use dusk_poseidon::sponge;
+use poseidon_merkle::{Item, Opening, Tree};
+use rand_core::{CryptoRng, RngCore};
+
+// Example values
+const USER_ATTRIBUTES: u64 = 112233445566778899u64;
+const CHALLENGE: u64 = 20221126u64;
+
+pub struct CitadelUtils {}
+
+impl CitadelUtils {
+    pub fn compute_random_license<
+        R: RngCore + CryptoRng,
+        const DEPTH: usize,
+        const ARITY: usize,
+    >(
+        rng: &mut R,
+        ssk: SecretSpendKey,
+        psk: PublicSpendKey,
+        ssk_lp: SecretSpendKey,
+        psk_lp: PublicSpendKey,
+    ) -> (License, Opening<(), DEPTH, ARITY>) {
+        // First, the user computes these values and requests a License
+        let lsa = psk.gen_stealth_address(&JubJubScalar::random(rng));
+        let lsk = ssk.sk_r(&lsa);
+        let k_lic = JubJubAffine::from(
+            GENERATOR_EXTENDED * sponge::truncated::hash(&[(*lsk.as_ref()).into()]),
+        );
+        let req = Request::new(&psk_lp, &lsa, &k_lic, rng);
+
+        // Second, the LP computes these values and grants the License
+        let attr = JubJubScalar::from(USER_ATTRIBUTES);
+        let mut lic = License::new(&attr, &ssk_lp, &req, rng);
+
+        let mut tree = Tree::<(), DEPTH, ARITY>::new();
+        let lpk = JubJubAffine::from(lic.lsa.pk_r().as_ref());
+
+        let item = Item {
+            hash: sponge::hash(&[lpk.get_x(), lpk.get_y()]),
+            data: (),
+        };
+
+        lic.pos = 0;
+        tree.insert(lic.pos, item);
+
+        let merkle_proof = tree.opening(lic.pos).expect("Tree was read successfully");
+
+        (lic, merkle_proof)
+    }
+
+    pub fn compute_citadel_parameters<
+        R: RngCore + CryptoRng,
+        const DEPTH: usize,
+        const ARITY: usize,
+    >(
+        rng: &mut R,
+        ssk: SecretSpendKey,
+        psk: PublicSpendKey,
+        ssk_lp: SecretSpendKey,
+        psk_lp: PublicSpendKey,
+    ) -> (CitadelProverParameters<DEPTH, ARITY>, SessionCookie) {
+        let (lic, merkle_proof) =
+            Self::compute_random_license::<R, DEPTH, ARITY>(rng, ssk, psk, ssk_lp, psk_lp);
+
+        let c = JubJubScalar::from(CHALLENGE);
+        let (cpp, sc) = CitadelProverParameters::compute_parameters(
+            &ssk,
+            &lic,
+            &psk_lp,
+            &psk_lp,
+            &c,
+            rng,
+            merkle_proof,
+        );
+        (cpp, sc)
+    }
+}

--- a/tests/citadel.rs
+++ b/tests/citadel.rs
@@ -4,13 +4,8 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use dusk_jubjub::GENERATOR_EXTENDED;
-
-use poseidon_merkle::{Item, Opening, Tree};
-
 use dusk_pki::{PublicSpendKey, SecretSpendKey};
 use dusk_plonk::prelude::*;
-use dusk_poseidon::sponge;
 
 static LABEL: &[u8; 12] = b"dusk-network";
 
@@ -20,16 +15,16 @@ const ARITY: usize = 4; // arity of the Merkle tree
 
 use zk_citadel::gadgets;
 use zk_citadel::license::{
-    CitadelProverParameters, License, Request, Session, SessionCookie, ShelterProverParameters,
+    CitadelProverParameters, Session, SessionCookie, ShelterProverParameters,
 };
 
-use rand_core::{CryptoRng, OsRng, RngCore};
+use rand_core::OsRng;
+use zk_citadel::utils::CitadelUtils;
 
 #[macro_use]
 extern crate lazy_static;
 
-// Example values
-const USER_ATTRIBUTES: u64 = 112233445566778899u64;
+// Example value
 const CHALLENGE: u64 = 20221126u64;
 
 pub struct Keys {
@@ -112,51 +107,14 @@ impl Circuit for Shelter {
     }
 }
 
-fn compute_random_license<R: RngCore + CryptoRng>(
-    rng: &mut R,
-) -> (License, Opening<(), DEPTH, ARITY>) {
-    // First, the user computes these values and requests a License
-    let lsa = KEYS.psk.gen_stealth_address(&JubJubScalar::random(rng));
-    let lsk = KEYS.ssk.sk_r(&lsa);
-    let k_lic =
-        JubJubAffine::from(GENERATOR_EXTENDED * sponge::truncated::hash(&[(*lsk.as_ref()).into()]));
-    let req = Request::new(&KEYS.psk_lp, &lsa, &k_lic, rng);
-
-    // Second, the LP computes these values and grants the License
-    let attr = JubJubScalar::from(USER_ATTRIBUTES);
-    let mut lic = License::new(&attr, &KEYS.ssk_lp, &req, rng);
-
-    let mut tree = Tree::<(), DEPTH, ARITY>::new();
-    let lpk = JubJubAffine::from(lic.lsa.pk_r().as_ref());
-
-    let item = Item {
-        hash: sponge::hash(&[lpk.get_x(), lpk.get_y()]),
-        data: (),
-    };
-
-    lic.pos = 0;
-    tree.insert(lic.pos, item);
-
-    let merkle_proof = tree.opening(lic.pos).expect("Tree was read successfully");
-
-    (lic, merkle_proof)
-}
-
 #[test]
 fn test_full_citadel() {
-    // We generate a random license and merkle proof for testing
-    let (lic, merkle_proof) = compute_random_license(&mut OsRng);
-
-    // The user computes these values to use a license
-    let c = JubJubScalar::from(CHALLENGE);
-    let (cpp, sc) = CitadelProverParameters::compute_parameters(
-        &KEYS.ssk,
-        &lic,
-        &KEYS.psk_lp,
-        &KEYS.psk_lp,
-        &c,
+    let (cpp, sc) = CitadelUtils::compute_citadel_parameters::<OsRng, DEPTH, ARITY>(
         &mut OsRng,
-        merkle_proof,
+        KEYS.ssk,
+        KEYS.psk,
+        KEYS.ssk_lp,
+        KEYS.psk_lp,
     );
 
     // Then, the user generates the proof
@@ -179,7 +137,13 @@ fn test_full_citadel() {
 #[test]
 fn test_full_shelter() {
     // We generate a random license and merkle proof for testing
-    let (lic, merkle_proof) = compute_random_license(&mut OsRng);
+    let (lic, merkle_proof) = CitadelUtils::compute_random_license::<OsRng, DEPTH, ARITY>(
+        &mut OsRng,
+        KEYS.ssk,
+        KEYS.psk,
+        KEYS.ssk_lp,
+        KEYS.psk_lp,
+    );
 
     // The user computes these values to use a license
     let c = JubJubScalar::from(CHALLENGE);
@@ -206,17 +170,12 @@ fn test_full_shelter() {
 #[test]
 #[should_panic]
 fn test_citadel_false_public_input() {
-    let (lic, merkle_proof) = compute_random_license(&mut OsRng);
-
-    let c = JubJubScalar::from(CHALLENGE);
-    let (cpp, sc) = CitadelProverParameters::compute_parameters(
-        &KEYS.ssk,
-        &lic,
-        &KEYS.psk_lp,
-        &KEYS.psk_lp,
-        &c,
+    let (cpp, sc) = CitadelUtils::compute_citadel_parameters::<OsRng, DEPTH, ARITY>(
         &mut OsRng,
-        merkle_proof,
+        KEYS.ssk,
+        KEYS.psk,
+        KEYS.ssk_lp,
+        KEYS.psk_lp,
     );
 
     let (proof, public_inputs) = KEYS
@@ -236,7 +195,14 @@ fn test_citadel_false_public_input() {
 #[test]
 #[should_panic]
 fn test_shelter_false_public_input() {
-    let (lic, merkle_proof) = compute_random_license(&mut OsRng);
+    let (lic, merkle_proof) =
+        CitadelUtils::compute_random_license::<OsRng, DEPTH, ARITY>(
+            &mut OsRng,
+            KEYS.ssk,
+            KEYS.psk,
+            KEYS.ssk_lp,
+            KEYS.psk_lp,
+        );
 
     let c = JubJubScalar::from(CHALLENGE);
     let spp = ShelterProverParameters::compute_parameters(
@@ -264,17 +230,12 @@ fn test_shelter_false_public_input() {
 #[test]
 #[should_panic]
 fn test_citadel_false_session_cookie() {
-    let (lic, merkle_proof) = compute_random_license(&mut OsRng);
-
-    let c = JubJubScalar::from(CHALLENGE);
-    let (cpp, sc) = CitadelProverParameters::compute_parameters(
-        &KEYS.ssk,
-        &lic,
-        &KEYS.psk_lp,
-        &KEYS.psk_lp,
-        &c,
+    let (cpp, sc) = CitadelUtils::compute_citadel_parameters::<OsRng, DEPTH, ARITY>(
         &mut OsRng,
-        merkle_proof,
+        KEYS.ssk,
+        KEYS.psk,
+        KEYS.ssk_lp,
+        KEYS.psk_lp,
     );
 
     let (_proof, public_inputs) = KEYS

--- a/tests/citadel.rs
+++ b/tests/citadel.rs
@@ -195,14 +195,13 @@ fn test_citadel_false_public_input() {
 #[test]
 #[should_panic]
 fn test_shelter_false_public_input() {
-    let (lic, merkle_proof) =
-        CitadelUtils::compute_random_license::<OsRng, DEPTH, ARITY>(
-            &mut OsRng,
-            KEYS.ssk,
-            KEYS.psk,
-            KEYS.ssk_lp,
-            KEYS.psk_lp,
-        );
+    let (lic, merkle_proof) = CitadelUtils::compute_random_license::<OsRng, DEPTH, ARITY>(
+        &mut OsRng,
+        KEYS.ssk,
+        KEYS.psk,
+        KEYS.ssk_lp,
+        KEYS.psk_lp,
+    );
 
     let c = JubJubScalar::from(CHALLENGE);
     let spp = ShelterProverParameters::compute_parameters(


### PR DESCRIPTION
Reuse test code to eliminate repetition:
methods `compute_random_license` and `compute_citadel_parameters` are duplicated
in `bench` and in tests of Citadel, as well as in circuits/license tests in Rusk and in contracts/license tests in Rusk.
This PR attempts to address this 4x repetition.