### PR TITLE
Remove pos from license, refactor utils to accept license and opening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Removed pos field from the license struct
+- Refactored utils to accept external license and opening
+
 ## [0.4.1] - 2023-08-09
 
 ### Added

--- a/benches/citadel.rs
+++ b/benches/citadel.rs
@@ -160,12 +160,20 @@ fn shelter_benchmark(crit: &mut Criterion) {
 }
 
 fn citadel_benchmark(crit: &mut Criterion) {
-    let (cpp, sc) = CitadelUtils::compute_citadel_parameters::<OsRng, DEPTH_CITADEL, ARITY>(
-        &mut OsRng,
+    let (lic, merkle_proof) = Self::compute_random_license::<R, DEPTH, ARITY>(
+        OsRng,
         KEYS.ssk,
         KEYS.psk,
         KEYS.ssk_lp,
         KEYS.psk_lp,
+    );
+
+    let (cpp, sc) = CitadelUtils::compute_citadel_parameters::<OsRng, DEPTH_CITADEL, ARITY>(
+        &mut OsRng,
+        KEYS.ssk,
+        KEYS.psk_lp,
+        &lic,
+        merkle_proof,
     );
 
     unsafe {

--- a/src/license.rs
+++ b/src/license.rs
@@ -161,7 +161,6 @@ pub struct License {
     pub nonce_1: BlsScalar,    // IV for the encryption
     pub enc_2: PoseidonCipher, // encryption of the license signature and attributes
     pub nonce_2: BlsScalar,    // IV for the encryption
-    pub pos: u64,              // position of the license in the Merkle tree of licenses
 }
 
 impl License {
@@ -209,8 +208,6 @@ impl License {
         let enc_2 =
             PoseidonCipher::encrypt(&[sig_lic_r.get_x(), sig_lic_r.get_y()], &k_lic, &nonce_2);
 
-        let pos = 0u64;
-
         Self {
             lsa: StealthAddress::from_raw_unchecked(
                 JubJubExtended::from(r),
@@ -220,7 +217,6 @@ impl License {
             nonce_1,
             enc_2,
             nonce_2,
-            pos,
         }
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -39,7 +39,7 @@ impl CitadelUtils {
 
         // Second, the LP computes these values and grants the License
         let attr = JubJubScalar::from(USER_ATTRIBUTES);
-        let mut lic = License::new(&attr, &ssk_lp, &req, rng);
+        let lic = License::new(&attr, &ssk_lp, &req, rng);
 
         let mut tree = Tree::<(), DEPTH, ARITY>::new();
         let lpk = JubJubAffine::from(lic.lsa.pk_r().as_ref());
@@ -49,10 +49,10 @@ impl CitadelUtils {
             data: (),
         };
 
-        lic.pos = 0;
-        tree.insert(lic.pos, item);
+        let pos = 0;
+        tree.insert(pos, item);
 
-        let merkle_proof = tree.opening(lic.pos).expect("Tree was read successfully");
+        let merkle_proof = tree.opening(pos).expect("Tree was read successfully");
 
         (lic, merkle_proof)
     }
@@ -64,13 +64,10 @@ impl CitadelUtils {
     >(
         rng: &mut R,
         ssk: SecretSpendKey,
-        psk: PublicSpendKey,
-        ssk_lp: SecretSpendKey,
         psk_lp: PublicSpendKey,
+        lic: &License,
+        merkle_proof: Opening<(), DEPTH, ARITY>,
     ) -> (CitadelProverParameters<DEPTH, ARITY>, SessionCookie) {
-        let (lic, merkle_proof) =
-            Self::compute_random_license::<R, DEPTH, ARITY>(rng, ssk, psk, ssk_lp, psk_lp);
-
         let c = JubJubScalar::from(CHALLENGE);
         let (cpp, sc) = CitadelProverParameters::compute_parameters(
             &ssk,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -71,7 +71,7 @@ impl CitadelUtils {
         let c = JubJubScalar::from(CHALLENGE);
         let (cpp, sc) = CitadelProverParameters::compute_parameters(
             &ssk,
-            &lic,
+            lic,
             &psk_lp,
             &psk_lp,
             &c,

--- a/tests/citadel.rs
+++ b/tests/citadel.rs
@@ -109,12 +109,20 @@ impl Circuit for Shelter {
 
 #[test]
 fn test_full_citadel() {
-    let (cpp, sc) = CitadelUtils::compute_citadel_parameters::<OsRng, DEPTH, ARITY>(
+    let (lic, merkle_proof) = CitadelUtils::compute_random_license::<OsRng, DEPTH, ARITY>(
         &mut OsRng,
         KEYS.ssk,
         KEYS.psk,
         KEYS.ssk_lp,
         KEYS.psk_lp,
+    );
+
+    let (cpp, sc) = CitadelUtils::compute_citadel_parameters::<OsRng, DEPTH, ARITY>(
+        &mut OsRng,
+        KEYS.ssk,
+        KEYS.psk_lp,
+        &lic,
+        merkle_proof,
     );
 
     // Then, the user generates the proof
@@ -170,12 +178,20 @@ fn test_full_shelter() {
 #[test]
 #[should_panic]
 fn test_citadel_false_public_input() {
-    let (cpp, sc) = CitadelUtils::compute_citadel_parameters::<OsRng, DEPTH, ARITY>(
+    let (lic, merkle_proof) = CitadelUtils::compute_random_license::<OsRng, DEPTH, ARITY>(
         &mut OsRng,
         KEYS.ssk,
         KEYS.psk,
         KEYS.ssk_lp,
         KEYS.psk_lp,
+    );
+
+    let (cpp, sc) = CitadelUtils::compute_citadel_parameters::<OsRng, DEPTH, ARITY>(
+        &mut OsRng,
+        KEYS.ssk,
+        KEYS.psk_lp,
+        &lic,
+        merkle_proof,
     );
 
     let (proof, public_inputs) = KEYS
@@ -229,12 +245,20 @@ fn test_shelter_false_public_input() {
 #[test]
 #[should_panic]
 fn test_citadel_false_session_cookie() {
-    let (cpp, sc) = CitadelUtils::compute_citadel_parameters::<OsRng, DEPTH, ARITY>(
+    let (lic, merkle_proof) = CitadelUtils::compute_random_license::<OsRng, DEPTH, ARITY>(
         &mut OsRng,
         KEYS.ssk,
         KEYS.psk,
         KEYS.ssk_lp,
         KEYS.psk_lp,
+    );
+
+    let (cpp, sc) = CitadelUtils::compute_citadel_parameters::<OsRng, DEPTH, ARITY>(
+        &mut OsRng,
+        KEYS.ssk,
+        KEYS.psk_lp,
+        &lic,
+        merkle_proof,
     );
 
     let (_proof, public_inputs) = KEYS


### PR DESCRIPTION
Remove the pos (position) field from the license struct, refactor LicenseUtils to accept external license and opening rather than creating mock ones.

Implements issues #74, #75
