### PR TITLE
Bump to v0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1] - 2023-11-01
+
 ### Changed
 
 - fixed benches
@@ -91,7 +93,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#21]: https://github.com/dusk-network/citadel/issues/21
 
 <!-- VERSIONS -->
-[Unreleased]: https://github.com/dusk-network/citadel/compare/v0.5.0...HEAD
+[Unreleased]: https://github.com/dusk-network/citadel/compare/v0.5.1...HEAD
+[0.5.1]: https://github.com/dusk-network/citadel/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/dusk-network/citadel/compare/v0.4.1...v0.5.0
 [0.4.1]: https://github.com/dusk-network/citadel/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/dusk-network/citadel/compare/v0.3.0...v0.4.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zk-citadel"
-version = "0.5.0"
+version = "0.5.1"
 repository = "https://github.com/dusk-network/citadel"
 description = "Implementation of Citadel, a SSI system integrated in Dusk Network."
 categories = ["cryptography", "authentication", "mathematics", "science"]


### PR DESCRIPTION
## [0.5.1] - 2023-11-01

### Changed

- fixed benches
- Change `attr` to `attr_data`[#80]

[0.5.1]: https://github.com/dusk-network/citadel/compare/v0.5.0...v0.5.1
