### PR TITLE
Bump to v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0] - 2023-12-13
+
 ### Addded
 
 - Add `phoenix-core` dependency at "0.23"
@@ -19,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update `dusk-poseidon` dependency to "0.32"
 - Update `poseidon-merkle` dependency to "0.4"
 - Update `dusk-plonk` dependency to "0.18"
+- Restructure specs [#86]
 
 ### Removed
 
@@ -111,6 +114,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- ISSUES -->
 [#87]: https://github.com/dusk-network/citadel/issues/87
+[#86]: https://github.com/dusk-network/citadel/issues/86
 [#80]: https://github.com/dusk-network/citadel/issues/80
 [#54]: https://github.com/dusk-network/citadel/issues/54
 [#41]: https://github.com/dusk-network/citadel/issues/41
@@ -121,7 +125,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#21]: https://github.com/dusk-network/citadel/issues/21
 
 <!-- VERSIONS -->
-[Unreleased]: https://github.com/dusk-network/citadel/compare/v0.6.0...HEAD
+[Unreleased]: https://github.com/dusk-network/citadel/compare/v0.7.0...HEAD
+[0.7.0]: https://github.com/dusk-network/citadel/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/dusk-network/citadel/compare/v0.5.1...v0.6.0
 [0.5.1]: https://github.com/dusk-network/citadel/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/dusk-network/citadel/compare/v0.4.1...v0.5.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zk-citadel"
-version = "0.6.0"
+version = "0.7.0"
 repository = "https://github.com/dusk-network/citadel"
 description = "Implementation of Citadel, a SSI system integrated in Dusk Network."
 categories = ["cryptography", "authentication", "mathematics", "science"]


### PR DESCRIPTION
## [0.7.0] - 2023-12-13

### Addded

- Add `phoenix-core` dependency at "0.23"

### Changed

- Update `dusk-bls12_381` dependency to "0.13"
- Update `dusk-jubjub` dependency to "0.14"
- Update `dusk-schnorr` dependency to "0.17"
- Update `dusk-poseidon` dependency to "0.32"
- Update `poseidon-merkle` dependency to "0.4"
- Update `dusk-plonk` dependency to "0.18"

### Removed

- Remove `dusk-pki` dependency


[0.7.0]: https://github.com/dusk-network/citadel/compare/v0.6.0...v0.7.0
