### PR TITLE
Bump to v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0] - 2024-01-03
+
 ### Changed
 
 - Update `dusk-schnorr` dependency to "0.18"
@@ -133,7 +135,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#21]: https://github.com/dusk-network/citadel/issues/21
 
 <!-- VERSIONS -->
-[Unreleased]: https://github.com/dusk-network/citadel/compare/v0.7.0...HEAD
+[Unreleased]: https://github.com/dusk-network/citadel/compare/v0.8.0...HEAD
+[0.8.0]: https://github.com/dusk-network/citadel/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/dusk-network/citadel/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/dusk-network/citadel/compare/v0.5.1...v0.6.0
 [0.5.1]: https://github.com/dusk-network/citadel/compare/v0.5.0...v0.5.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zk-citadel"
-version = "0.7.0"
+version = "0.8.0"
 repository = "https://github.com/dusk-network/citadel"
 description = "Implementation of Citadel, a SSI system integrated in Dusk Network."
 categories = ["cryptography", "authentication", "mathematics", "science"]


### PR DESCRIPTION
## [0.8.0] - 2024-01-03

### Changed

- Update `dusk-schnorr` dependency to "0.18"
- Update `dusk-poseidon` dependency to "0.33"
- Update `poseidon-merkle` dependency to "0.5"
- Update `dusk-plonk` dependency to "0.19"
- Update `phoenix-core` dependency to "0.24"

[0.8.0]: https://github.com/dusk-network/citadel/compare/v0.7.0...v0.8.0
