### PR TITLE
Bump to v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0] - 2024-01-24
+
 ### Changed
 
 - Exchanged `dusk-schnorr@0.18` dependency for `jubjub-schnorr@0.1`
@@ -139,7 +141,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#21]: https://github.com/dusk-network/citadel/issues/21
 
 <!-- VERSIONS -->
-[Unreleased]: https://github.com/dusk-network/citadel/compare/v0.8.0...HEAD
+[Unreleased]: https://github.com/dusk-network/citadel/compare/v0.9.0...HEAD
+[0.9.0]: https://github.com/dusk-network/citadel/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/dusk-network/citadel/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/dusk-network/citadel/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/dusk-network/citadel/compare/v0.5.1...v0.6.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zk-citadel"
-version = "0.9.0-rc.0"
+version = "0.9.0"
 repository = "https://github.com/dusk-network/citadel"
 description = "Implementation of Citadel, a SSI system integrated in Dusk Network."
 categories = ["cryptography", "authentication", "mathematics", "science"]


### PR DESCRIPTION
## [0.9.0] - 2024-01-24

### Changed

- Exchanged `dusk-schnorr@0.18` dependency for `jubjub-schnorr@0.1`



[0.9.0]: https://github.com/dusk-network/citadel/compare/v0.8.0...v0.9.0

