### PR TITLE
Bump to v0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.0] - 2024-04-10
+
 ### Changed
 
 - Update `jubjub-schnorr` dependency to "0.2"
@@ -152,7 +154,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#21]: https://github.com/dusk-network/citadel/issues/21
 
 <!-- VERSIONS -->
-[Unreleased]: https://github.com/dusk-network/citadel/compare/v0.10.0...HEAD
+[Unreleased]: https://github.com/dusk-network/citadel/compare/v0.11.0...HEAD
+[0.11.0]: https://github.com/dusk-network/citadel/compare/v0.10.0...v0.11.0
 [0.10.0]: https://github.com/dusk-network/citadel/compare/v0.9.0...v0.10.0
 [0.9.0]: https://github.com/dusk-network/citadel/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/dusk-network/citadel/compare/v0.7.0...v0.8.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zk-citadel"
-version = "0.10.0"
+version = "0.11.0"
 repository = "https://github.com/dusk-network/citadel"
 description = "Implementation of Citadel, a SSI system integrated in Dusk Network."
 categories = ["cryptography", "authentication", "mathematics", "science"]


### PR DESCRIPTION
## [0.11.0] - 2024-04-10

### Changed

- Update `jubjub-schnorr` dependency to "0.2"
- Update `phoenix-core` dependency to "0.26"


[0.11.0]: https://github.com/dusk-network/citadel/compare/v0.10.0...v0.11.0
