### PR TITLE
Bump to v0.12.0-rc.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Update `jubjub-schnorr` dependency to "0.4"
-- Update `phoenix-core` dependency to "0.28"
+- Update `phoenix-core` dependency to "0.30.0-rc"
 - Use AES instead of PoseidonCipher [#109]
 - Update `dusk-poseidon` dependency to "0.39" [#111]
 - Update `poseidon-merkle` dependency to "0.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zk-citadel"
-version = "0.11.0"
+version = "0.12.0-rc.0"
 repository = "https://github.com/dusk-network/citadel"
 description = "Implementation of Citadel, a SSI system integrated in Dusk Network."
 categories = ["cryptography", "authentication", "mathematics", "science"]


### PR DESCRIPTION
### Changed

- Update `jubjub-schnorr` dependency to "0.4"
- Update `phoenix-core` dependency to "0.30.0-rc"
- Use AES instead of PoseidonCipher [#109]
- Update `dusk-poseidon` dependency to "0.39" [#111]
- Update `poseidon-merkle` dependency to "0.6"

### Removed

- Remove `utils` module as it was only used for testing
- Remove `nstack` dependency [#113]
