### PR TITLE
Bump to v0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.0] - 2024-07-03
+
 ### Changed
 
 - Update `jubjub-schnorr` dependency to "0.4"
@@ -170,7 +172,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#21]: https://github.com/dusk-network/citadel/issues/21
 
 <!-- VERSIONS -->
-[Unreleased]: https://github.com/dusk-network/citadel/compare/v0.11.0...HEAD
+[Unreleased]: https://github.com/dusk-network/citadel/compare/v0.12.0...HEAD
+[0.12.0]: https://github.com/dusk-network/citadel/compare/v0.11.0...v0.12.0
 [0.11.0]: https://github.com/dusk-network/citadel/compare/v0.10.0...v0.11.0
 [0.10.0]: https://github.com/dusk-network/citadel/compare/v0.9.0...v0.10.0
 [0.9.0]: https://github.com/dusk-network/citadel/compare/v0.8.0...v0.9.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zk-citadel"
-version = "0.12.0-rc.0"
+version = "0.12.0"
 repository = "https://github.com/dusk-network/citadel"
 description = "Implementation of Citadel, a SSI system integrated in Dusk Network."
 categories = ["cryptography", "authentication", "mathematics", "science"]
@@ -17,7 +17,7 @@ dusk-bls12_381 = { version = "0.13", default-features = false, features = ["rkyv
 dusk-jubjub = { version = "0.14", default-features = false, features = ["rkyv-impl", "alloc"] }
 ff = { version = "0.13", default-features = false }
 jubjub-schnorr = { version = "0.4", features = ["zk", "rkyv-impl", "alloc"] }
-phoenix-core = { version = "0.30.0-rc", features = ["rkyv-impl", "alloc"] }
+phoenix-core = { version = "0.30", features = ["rkyv-impl", "alloc"] }
 rand_core = { version = "0.6", default-features=false, features = ["getrandom"] }
 rkyv = { version = "0.7", default-features = false }
 bytecheck = { version = "0.6", default-features = false }


### PR DESCRIPTION
## [0.12.0] - 2024-07-03

### Changed

- Update `jubjub-schnorr` dependency to "0.4"
- Update `phoenix-core` dependency to "0.30.0-rc"
- Use AES instead of PoseidonCipher [#109]
- Update `dusk-poseidon` dependency to "0.39" [#111]
- Update `poseidon-merkle` dependency to "0.6"

### Removed

- Remove `utils` module as it was only used for testing
- Remove `nstack` dependency [#113]


[0.12.0]: https://github.com/dusk-network/citadel/compare/v0.11.0...v0.12.0
