### PR TITLE
Bump to v0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.0] - 2024-08-14
+
 ### Changed
 
-- Update `phoenix-core` dependency to "0.31.0-rc"
+- Update `phoenix-core` dependency to "0.32"
+- Update dusk-plonk to v0.20
+- Update dusk-poseidon to v0.40
+- Update jubjub-schnorr to v0.5
+- Update poseidon-merkle to v0.7
 
 ## [0.12.0] - 2024-07-03
 
@@ -176,7 +182,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#21]: https://github.com/dusk-network/citadel/issues/21
 
 <!-- VERSIONS -->
-[Unreleased]: https://github.com/dusk-network/citadel/compare/v0.12.0...HEAD
+[Unreleased]: https://github.com/dusk-network/citadel/compare/v0.14.0...HEAD
+[0.14.0]: https://github.com/dusk-network/citadel/compare/v0.12.0...v0.14.0
 [0.12.0]: https://github.com/dusk-network/citadel/compare/v0.11.0...v0.12.0
 [0.11.0]: https://github.com/dusk-network/citadel/compare/v0.10.0...v0.11.0
 [0.10.0]: https://github.com/dusk-network/citadel/compare/v0.9.0...v0.10.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zk-citadel"
-version = "0.13.0-rc.0"
+version = "0.14.0"
 repository = "https://github.com/dusk-network/citadel"
 description = "Implementation of Citadel, a SSI system integrated in Dusk Network."
 categories = ["cryptography", "authentication", "mathematics", "science"]
@@ -10,14 +10,14 @@ license = "MPL-2.0"
 
 [dependencies]
 dusk-bytes = "0.1"
-dusk-poseidon = { version = "0.39", features = ["zk"] }
-poseidon-merkle = { version = "0.6", features = ["rkyv-impl", "zk", "size_32"] }
-dusk-plonk = { version = "0.19", default-features = false, features = ["rkyv-impl", "alloc"] }
+dusk-poseidon = { version = "0.40", features = ["zk"] }
+poseidon-merkle = { version = "0.7", features = ["rkyv-impl", "zk", "size_32"] }
+dusk-plonk = { version = "0.20", default-features = false, features = ["rkyv-impl", "alloc"] }
 dusk-bls12_381 = { version = "0.13", default-features = false, features = ["rkyv-impl", "alloc"] }
 dusk-jubjub = { version = "0.14", default-features = false, features = ["rkyv-impl", "alloc"] }
 ff = { version = "0.13", default-features = false }
-jubjub-schnorr = { version = "0.4", features = ["zk", "rkyv-impl", "alloc"] }
-phoenix-core = { version = "0.31.0-rc.0", features = ["rkyv-impl", "alloc"] }
+jubjub-schnorr = { version = "0.5", features = ["zk", "rkyv-impl", "alloc"] }
+phoenix-core = { version = "0.32", features = ["rkyv-impl", "alloc"] }
 rand_core = { version = "0.6", default-features=false, features = ["getrandom"] }
 rkyv = { version = "0.7", default-features = false }
 bytecheck = { version = "0.6", default-features = false }


### PR DESCRIPTION
## [0.14.0] - 2024-08-14

### Changed

- Update phoenix-core to v0.32
- Update dusk-plonk to v0.20
- Update dusk-poseidon to v0.40
- Update jubjub-schnorr to v0.5
- Update poseidon-merkle to v0.7

[0.14.0]: https://github.com/dusk-network/citadel/compare/v0.14.0...v0.14.0