### PR TITLE
Allow creation of licenses without Request

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,6 @@ This repository is structured as follows:
 
 - :computer: [**Core**](core): the core Citadel protocol implementation, containing all the involved data types, the protocol workflows, and the license circuit.
 - :pencil: [**License Contract**](contract): The license contract, along with all the required code to test and deploy it.
-- :scroll: [**Docs**](docs): A folder where you can find the documentation concerning the our Citadel specific implementation.
+- :scroll: [**Docs**](docs): A folder where you can find the documentation concerning our Citadel specific implementation.
 
 **DISCLAIMER**: the code in this repository **has not gone through an exhaustive security analysis**, so it is not intended to be used in a production environment, only for academic purposes.

--- a/contract/CHANGELOG.md
+++ b/contract/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changed 'issue_license' by removing the 'pos' argument and self position determination [#1039]
 - Fixed `license` tests error when creating `PublicParameters` from a slice
 - Moved the `license-contract` to the `Citadel` repository [#122]
+- Changed tests to match the new `core` API
 
 ## [0.1.0] - 2023-07-13
 

--- a/contract/tests/license_contract.rs
+++ b/contract/tests/license_contract.rs
@@ -16,7 +16,7 @@ use ff::Field;
 use rand::rngs::StdRng;
 use rand::{CryptoRng, RngCore, SeedableRng};
 use rkyv::{check_archived_root, Deserialize, Infallible};
-use zk_citadel::{circuit, gadgets, License, Request, SessionCookie};
+use zk_citadel::{circuit, gadgets, License, LicenseCreator, Request, SessionCookie};
 
 const PROVER_BYTES: &[u8] = include_bytes!("../../target/prover");
 
@@ -57,7 +57,7 @@ fn create_test_license<R: RngCore + CryptoRng>(
     rng: &mut R,
 ) -> License {
     let request = Request::new(pk_lp, sa_user, k_lic, rng).unwrap();
-    License::new(attr, sk_lp, &request, rng).unwrap()
+    License::new(attr, sk_lp, &LicenseCreator::FromRequest(request), rng).unwrap()
 }
 
 fn initialize() -> Session {
@@ -319,7 +319,7 @@ fn use_license_get_session() {
 
     let request = create_request(&sk_user, &pk_lp, rng);
     let attr = JubJubScalar::from(USER_ATTRIBUTES);
-    let license = License::new(&attr, &sk_lp, &request, rng).unwrap();
+    let license = License::new(&attr, &sk_lp, &LicenseCreator::FromRequest(request), rng).unwrap();
 
     let license_blob = rkyv::to_bytes::<_, 4096>(&license)
         .expect("Request should serialize correctly")

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add `circuit` module
+- Add `LicenseCreator`
 
 ### Changed
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -12,6 +12,6 @@ mod session;
 pub mod circuit;
 pub mod gadgets;
 
-pub use license::License;
+pub use license::{License, LicenseCreator};
 pub use request::Request;
 pub use session::{Session, SessionCookie};

--- a/core/src/license.rs
+++ b/core/src/license.rs
@@ -7,10 +7,11 @@
 use dusk_bytes::Serializable;
 use dusk_jubjub::dhke;
 use dusk_poseidon::{Domain, Hash};
+use ff::Field;
 use jubjub_schnorr::{SecretKey as NoteSecretKey, Signature};
 use phoenix_core::{
     aes::{decrypt, encrypt, ENCRYPTION_EXTRA_SIZE},
-    Error, SecretKey, StealthAddress,
+    Error, PublicKey, SecretKey, StealthAddress,
 };
 
 use rand_core::{CryptoRng, RngCore};
@@ -24,6 +25,11 @@ use crate::request::{Request, REQ_PLAINTEXT_SIZE};
 
 pub(crate) const LIC_PLAINTEXT_SIZE: usize = Signature::SIZE + JubJubScalar::SIZE;
 const LIC_ENCRYPTION_SIZE: usize = LIC_PLAINTEXT_SIZE + ENCRYPTION_EXTRA_SIZE;
+
+pub enum LicenseCreator {
+    FromRequest(Request),
+    FromPublicKey(PublicKey),
+}
 
 #[cfg_attr(
     feature = "rkyv-impl",
@@ -40,19 +46,34 @@ impl License {
     pub fn new<R: RngCore + CryptoRng>(
         attr_data: &JubJubScalar,
         sk_lp: &SecretKey,
-        req: &Request,
+        lc: &LicenseCreator,
         rng: &mut R,
     ) -> Result<Self, Error> {
-        let k_dh = dhke(sk_lp.a(), req.rsa.R());
-        let dec: [u8; REQ_PLAINTEXT_SIZE] = decrypt(&k_dh, &req.enc)?;
+        let (lsa, k_lic) = match lc {
+            LicenseCreator::FromRequest(req) => {
+                let k_dh = dhke(sk_lp.a(), req.rsa.R());
+                let dec: [u8; REQ_PLAINTEXT_SIZE] = decrypt(&k_dh, &req.enc)?;
 
-        let mut lsa_bytes = [0u8; StealthAddress::SIZE];
-        lsa_bytes.copy_from_slice(&dec[..StealthAddress::SIZE]);
-        let lsa = StealthAddress::from_bytes(&lsa_bytes).expect("Deserialization was correct.");
+                let mut lsa_bytes = [0u8; StealthAddress::SIZE];
+                lsa_bytes.copy_from_slice(&dec[..StealthAddress::SIZE]);
+                let lsa =
+                    StealthAddress::from_bytes(&lsa_bytes).expect("Deserialization was correct.");
 
-        let mut k_lic_bytes = [0u8; JubJubAffine::SIZE];
-        k_lic_bytes.copy_from_slice(&dec[StealthAddress::SIZE..]);
-        let k_lic = JubJubAffine::from_bytes(k_lic_bytes).expect("Deserialization was correct.");
+                let mut k_lic_bytes = [0u8; JubJubAffine::SIZE];
+                k_lic_bytes.copy_from_slice(&dec[StealthAddress::SIZE..]);
+                let k_lic =
+                    JubJubAffine::from_bytes(k_lic_bytes).expect("Deserialization was correct.");
+
+                (lsa, k_lic)
+            }
+            LicenseCreator::FromPublicKey(pk_user) => {
+                let r_dh = JubJubScalar::random(&mut *rng);
+                let lsa = pk_user.gen_stealth_address(&r_dh);
+                let k_lic = dhke(&r_dh, pk_user.A());
+
+                (lsa, k_lic)
+            }
+        };
 
         let lpk = JubJubAffine::from(lsa.note_pk().as_ref());
 

--- a/core/src/license.rs
+++ b/core/src/license.rs
@@ -54,13 +54,11 @@ impl License {
         k_lic_bytes.copy_from_slice(&dec[StealthAddress::SIZE..]);
         let k_lic = JubJubAffine::from_bytes(k_lic_bytes).expect("Deserialization was correct.");
 
+        let lpk = JubJubAffine::from(lsa.note_pk().as_ref());
+
         let message = Hash::digest(
             Domain::Other,
-            &[
-                lsa.note_pk().as_ref().get_u(),
-                lsa.note_pk().as_ref().get_v(),
-                BlsScalar::from(*attr_data),
-            ],
+            &[lpk.get_u(), lpk.get_v(), BlsScalar::from(*attr_data)],
         )[0];
         let sig_lic = NoteSecretKey::from(sk_lp.a()).sign(rng, message);
 

--- a/core/tests/citadel.rs
+++ b/core/tests/citadel.rs
@@ -4,7 +4,7 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use dusk_jubjub::{JubJubAffine, JubJubScalar, GENERATOR_EXTENDED};
+use dusk_jubjub::{JubJubAffine, JubJubScalar};
 use dusk_plonk::prelude::*;
 use dusk_poseidon::{Domain, Hash};
 use ff::Field;
@@ -36,12 +36,7 @@ fn test_full_citadel() {
         .expect("failed to compile circuit");
 
     // To use Citadel, the user first computes these values and requests a License
-    let lsa = pk.gen_stealth_address(&JubJubScalar::random(&mut OsRng));
-    let lsk = sk.gen_note_sk(&lsa);
-    let k_lic = JubJubAffine::from(
-        GENERATOR_EXTENDED * Hash::digest_truncated(Domain::Other, &[(*lsk.as_ref()).into()])[0],
-    );
-    let req = Request::new(&pk_lp, &lsa, &k_lic, &mut OsRng).expect("Request correctly computed.");
+    let req = Request::new(&sk, &pk, &pk_lp, &mut OsRng).expect("Request correctly computed.");
 
     // Second, the LP computes these values and grants the License on-chain
     let attr_data = JubJubScalar::from(ATTRIBUTE_DATA);


### PR DESCRIPTION
This PR does the following:
- Allows LP to issue licenses without requiring a Request object
- Other API improvements 