### PR TITLE
Remove Request from contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ This repository is academic/prototype code and has not had exhaustive security r
   - [§3 Deployment Profile And Domain Separation](docs/specs.md#3-deployment-profile-and-domain-separation), [§4 Canonical Encoding And Validation](docs/specs.md#4-canonical-encoding-and-validation): deployment metadata, `deployment_id`, domain separation, and canonical encodings.
   - [§5 Cryptographic Building Blocks](docs/specs.md#5-cryptographic-building-blocks): Jubjub/Phoenix keys, Poseidon domains, stealth addresses, Schnorr, commitments, AEAD/KDF, Merkle tree.
   - [§6 Data Objects](docs/specs.md#6-data-objects): Request, License, Session, base cookie, selective-disclosure cookie formats.
-  - [§7 Contract State, Registry Policy, And Interfaces](docs/specs.md#7-contract-state-registry-policy-and-interfaces): request registry, license registry, metadata, root policy, and contract interfaces.
+  - [§7 Contract State, Registry Policy, And Interfaces](docs/specs.md#7-contract-state-registry-policy-and-interfaces): request transport, license registry, metadata, root policy, and contract interfaces.
   - [§8 Protocol Flow](docs/specs.md#8-protocol-flow): end-to-end issuance, proof, contract, and SP verification flow.
   - [§9 License Circuit](docs/specs.md#9-license-circuit): license circuit public inputs, private witnesses, and enforced statements.
   - [§10 Challenge And Reuse Semantics](docs/specs.md#10-challenge-and-reuse-semantics), [§11 Attributes And Disclosure](docs/specs.md#11-attributes-and-disclosure), [§12 Revocation, Expiration, And Replay](docs/specs.md#12-revocation-expiration-and-replay): challenge/nullifier semantics, attributes, selective disclosure, revocation, expiration, replay.
@@ -52,7 +52,7 @@ This repository is academic/prototype code and has not had exhaustive security r
   - `core/tests/assets.rs`: focused protocol object, session parsing, and cookie policy tests.
   - `core/benches/license_circuit.rs`: circuit benchmark.
 - `contract/` (`license-contract` crate): Dusk contract for license registry and session registry.
-  - `contract/src/state.rs`: contract state and methods: `insert_request`, `get_requests`, `get_request`, `issue_license`, `get_licenses`, `get_license`, `get_merkle_opening`, `use_license`, `get_session`, `get_metadata`, `get_current_root`, `get_accepted_roots`, `get_state_info`, `get_info`.
+  - `contract/src/state.rs`: contract state and methods: `issue_license`, `get_licenses`, `get_license`, `get_merkle_opening`, `use_license`, `get_session`, `get_metadata`, `get_current_root`, `get_accepted_roots`, `get_state_info`, `get_info`.
   - `contract/src/license_types.rs`: rkyv-serializable call/return types and public-input constants.
   - `contract/src/collection.rs`: simple in-memory map abstraction for contract state.
   - `contract/build.rs`: downloads or generates PlonK setup material and writes `target/prover` and `target/verifier` used by tests and contract build.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The protocol reference is [`docs/specs.md`](docs/specs.md). The threat model and
 This repository is structured as follows:
 
 - :computer: [**Core**](core): protocol objects, request/license/session workflows, domain-separated helpers, Citadel Schnorr transcripts, and the license circuit.
-- :pencil: [**License Contract**](contract): request registry, license registry, Merkle root history, proof verification, session registry, and deployment metadata.
+- :pencil: [**License Contract**](contract): license registry, Merkle root history, proof verification, session registry, and deployment metadata.
 - :scroll: [**Docs**](docs): the normative protocol specification and threat model for this prototype.
 
 ## Development

--- a/contract/README.md
+++ b/contract/README.md
@@ -3,7 +3,7 @@
 ![Build Status](https://github.com/dusk-network/citadel/actions/workflows/dusk_ci.yml/badge.svg)
 [![Repository](https://img.shields.io/badge/github-citadel-blueviolet?logo=github)](https://github.com/dusk-network/citadel)
 
-This package contains the Citadel contract. It stores encrypted requests for LP discovery, encrypted licenses and license hashes, accepted Merkle roots, public session records, and deployment metadata used by wallets and Service Providers.
+This package contains the Citadel contract. It stores encrypted licenses and license hashes, accepted Merkle roots, public session records, and deployment metadata used by wallets and Service Providers. Request delivery is handled outside the base contract by the selected deployment or application transport.
 
 **DISCLAIMER**: this contract **has not gone through an exhaustive security analysis**, so it is not intended to be used in a production environment, only for academic purposes.
 

--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -19,8 +19,8 @@ pub(crate) mod license_types;
 mod state;
 
 pub use license_types::{
-    ContractInfo, DeploymentMetadata, InsertRequestArg, IssueLicenseArg, LicenseSession,
-    LicenseSessionId, UseLicenseArg,
+    ContractInfo, DeploymentMetadata, IssueLicenseArg, LicenseSession, LicenseSessionId,
+    UseLicenseArg,
 };
 
 const VD_LICENSE_CIRCUIT: &[u8] = include_bytes!("../../target/verifier");

--- a/contract/src/license_types.rs
+++ b/contract/src/license_types.rs
@@ -11,8 +11,6 @@ use rkyv::{Archive, Deserialize, Serialize};
 
 use dusk_bls12_381::BlsScalar;
 
-/// Maximum encrypted request blob size accepted by the contract.
-pub const MAX_REQUEST_BLOB_SIZE: usize = 4096;
 /// Maximum encrypted license blob size accepted by the contract.
 pub const MAX_LICENSE_BLOB_SIZE: usize = 4096;
 /// Number of public inputs expected by the license-use verifier.
@@ -29,14 +27,6 @@ pub type LicenseTree<const H: usize> = poseidon_merkle::Tree<(), H>;
 /// Contract Merkle opening type for the configured Merkle height.
 #[allow(dead_code)]
 pub type LicenseOpening<const H: usize> = poseidon_merkle::Opening<(), H>;
-
-/// Insert Request Argument.
-#[derive(Debug, Clone, PartialEq, Archive, Serialize, Deserialize)]
-#[archive_attr(derive(CheckBytes))]
-pub struct InsertRequestArg {
-    /// Versioned encrypted request blob.
-    pub request: Vec<u8>,
-}
 
 /// Issue License Argument.
 #[derive(Debug, Clone, PartialEq, Archive, Serialize, Deserialize)]
@@ -114,8 +104,6 @@ pub struct DeploymentMetadata {
     pub root_history_size: u32,
     /// Number of public inputs required by the verifier.
     pub public_inputs_len: u32,
-    /// Maximum encrypted request blob size.
-    pub max_request_blob_size: u32,
     /// Maximum encrypted license blob size.
     pub max_license_blob_size: u32,
 }
@@ -124,8 +112,6 @@ pub struct DeploymentMetadata {
 #[derive(Debug, Clone, Copy, PartialEq, Archive, Serialize, Deserialize)]
 #[archive_attr(derive(CheckBytes))]
 pub struct ContractInfo {
-    /// Number of stored request blobs.
-    pub requests: u32,
     /// Number of stored license blobs.
     pub licenses: u32,
     /// Number of populated license-tree leaves.

--- a/contract/src/state.rs
+++ b/contract/src/state.rs
@@ -18,9 +18,9 @@ pub mod license_contract {
         collection::Map,
         error::Error,
         license_types::{
-            ContractInfo, DeploymentMetadata, InsertRequestArg, IssueLicenseArg, LicenseOpening,
-            LicenseSession, LicenseSessionId, LicenseTree, MAX_LICENSE_BLOB_SIZE,
-            MAX_REQUEST_BLOB_SIZE, PI_ROOT, PUBLIC_INPUTS_LEN, UseLicenseArg,
+            ContractInfo, DeploymentMetadata, IssueLicenseArg, LicenseOpening, LicenseSession,
+            LicenseSessionId, LicenseTree, MAX_LICENSE_BLOB_SIZE, PI_ROOT, PUBLIC_INPUTS_LEN,
+            UseLicenseArg,
         },
         verifier_data_license_circuit,
     };
@@ -35,12 +35,6 @@ pub mod license_contract {
     const CITADEL_LICENSE_HASH_V1_TAG: u64 = 0x04;
 
     #[derive(Debug, Clone, PartialEq)]
-    struct RequestEntry {
-        pub block_height: u64,
-        pub request: Vec<u8>,
-    }
-
-    #[derive(Debug, Clone, PartialEq)]
     struct LicenseEntry {
         pub block_height: u64,
         pub license: Vec<u8>,
@@ -49,8 +43,6 @@ pub mod license_contract {
     #[derive(Debug, Clone)]
     pub struct LicenseContractState {
         sessions: Map<LicenseSessionId, LicenseSession>,
-        requests: Map<u64, RequestEntry>,
-        request_payloads: Map<Vec<u8>, ()>,
         licenses: Map<u64, LicenseEntry>,
         license_hashes: Map<BlsScalar, ()>,
         accepted_roots: Vec<BlsScalar>,
@@ -61,8 +53,6 @@ pub mod license_contract {
         pub const fn new() -> Self {
             Self {
                 sessions: Map::new(),
-                requests: Map::new(),
-                request_payloads: Map::new(),
                 licenses: Map::new(),
                 license_hashes: Map::new(),
                 accepted_roots: Vec::new(),
@@ -73,52 +63,6 @@ pub mod license_contract {
         #[allow(dead_code)]
         fn identifier() -> &'static [u8; 7] {
             b"license"
-        }
-
-        /// Inserts an encrypted request into the collection of requests.
-        /// Method intended to be called by the user.
-        pub fn insert_request(&mut self, arg: InsertRequestArg) {
-            if arg.request.is_empty() {
-                panic!("Request cannot be empty");
-            }
-            if arg.request.len() > MAX_REQUEST_BLOB_SIZE {
-                panic!("Request exceeds maximum size");
-            }
-            if self.request_payloads.get(&arg.request).is_some() {
-                panic!("Request already inserted");
-            }
-
-            let position = self.requests.len() as u64;
-            let block_height = block_height();
-            self.request_payloads.insert(arg.request.clone(), ());
-            self.requests.insert(
-                position,
-                RequestEntry {
-                    block_height,
-                    request: arg.request,
-                },
-            );
-        }
-
-        /// Returns requests for a given range of block-heights.
-        /// Method intended to be called by License Providers.
-        #[contract(feeds = "(u64, Vec<u8>)")]
-        pub fn get_requests(&mut self, block_heights: Range<u64>) {
-            for (pos, request) in self
-                .requests
-                .entries_filter(|(_, re)| block_heights.contains(&re.block_height))
-                .map(|(pos, re)| (*pos, re.request.clone()))
-            {
-                feed((pos, request));
-            }
-        }
-
-        /// Returns a request at a given request position.
-        /// Method intended to be called by wallets, License Providers, and clients.
-        pub fn get_request(&self, position: u64) -> Option<Vec<u8>> {
-            self.requests
-                .get(&position)
-                .map(|entry| entry.request.clone())
         }
 
         /// Inserts a license into the collection of licenses.
@@ -283,7 +227,6 @@ pub mod license_contract {
                 merkle_depth: DEPTH as u32,
                 root_history_size: ROOT_HISTORY_SIZE as u32,
                 public_inputs_len: PUBLIC_INPUTS_LEN as u32,
-                max_request_blob_size: MAX_REQUEST_BLOB_SIZE as u32,
                 max_license_blob_size: MAX_LICENSE_BLOB_SIZE as u32,
             }
         }
@@ -301,7 +244,6 @@ pub mod license_contract {
         /// Named state summary for wallets, LPs, SPs, and web clients.
         pub fn get_state_info(&self) -> ContractInfo {
             ContractInfo {
-                requests: self.requests.len() as u32,
                 licenses: self.licenses.len() as u32,
                 tree_len: self.tree.len() as u32,
                 sessions: self.sessions.len() as u32,

--- a/contract/tests/license_contract.rs
+++ b/contract/tests/license_contract.rs
@@ -13,7 +13,7 @@ use dusk_bytes::Serializable;
 use rand::rngs::StdRng;
 use rand::{CryptoRng, RngCore, SeedableRng};
 use rkyv::{Deserialize, Infallible, check_archived_root};
-use zk_citadel::{License, LicenseOrigin, Request, SessionCookie, circuit, gadgets};
+use zk_citadel::{License, LicenseOrigin, SessionCookie, circuit, gadgets};
 
 const PROVER_BYTES: &[u8] = include_bytes!("../../target/prover");
 
@@ -50,16 +50,13 @@ const USER_ATTRIBUTES: u64 = 545072475273;
 fn create_test_license<R: RngCore + CryptoRng>(
     attr: &JubJubScalar,
     sk_lp: &SecretKey,
-    pk_lp: &PublicKey,
-    sk_user: &SecretKey,
     pk_user: &PublicKey,
     rng: &mut R,
 ) -> License {
-    let request = Request::new(sk_user, pk_user, pk_lp, rng).unwrap();
     License::new(
         attr,
         sk_lp,
-        &LicenseOrigin::FromRequest(Box::new(request)),
+        &LicenseOrigin::FromPublicKey(Box::new(*pk_user)),
         rng,
     )
     .unwrap()
@@ -71,14 +68,6 @@ fn issue_arg(license: &License, license_blob: Vec<u8>) -> IssueLicenseArg {
         license: license_blob,
         lpk_u: lpk.get_u(),
         lpk_v: lpk.get_v(),
-    }
-}
-
-fn insert_request_arg(request: &Request) -> InsertRequestArg {
-    InsertRequestArg {
-        request: rkyv::to_bytes::<_, 4096>(request)
-            .expect("Request should serialize correctly")
-            .to_vec(),
     }
 }
 
@@ -150,13 +139,12 @@ fn license_issue_get_merkle() {
 
     // license provider
     let sk_lp = SecretKey::random(rng);
-    let pk_lp = PublicKey::from(&sk_lp);
 
     let attr = JubJubScalar::from(USER_ATTRIBUTES);
 
-    let license = create_test_license(&attr, &sk_lp, &pk_lp, &sk_user, &pk_user, rng);
+    let license = create_test_license(&attr, &sk_lp, &pk_user, rng);
     let license_blob = rkyv::to_bytes::<_, 4096>(&license)
-        .expect("Request should serialize correctly")
+        .expect("License should serialize correctly")
         .to_vec();
 
     let issue_arg = issue_arg(&license, license_blob);
@@ -190,7 +178,7 @@ fn license_issue_get_merkle() {
 
     assert!(
         !pos_license_pairs.is_empty(),
-        "Call to getting a license request should return some licenses"
+        "Call to getting licenses should return some licenses"
     );
 
     let owned_license = find_owned_license(&sk_user, &pos_license_pairs);
@@ -207,108 +195,6 @@ fn license_issue_get_merkle() {
 }
 
 #[test]
-fn request_insert_get_and_duplicate_rejection() {
-    let rng = &mut StdRng::seed_from_u64(0xcafe);
-    let mut session = initialize();
-
-    let sk_user = SecretKey::random(rng);
-    let pk_user = PublicKey::from(&sk_user);
-    let sk_lp = SecretKey::random(rng);
-    let pk_lp = PublicKey::from(&sk_lp);
-    let request = Request::new(&sk_user, &pk_user, &pk_lp, rng).unwrap();
-    let insert_arg = insert_request_arg(&request);
-    let request_blob = insert_arg.request.clone();
-
-    session
-        .call::<InsertRequestArg, ()>(
-            LICENSE_CONTRACT_ID,
-            "insert_request",
-            &insert_arg,
-            POINT_LIMIT,
-        )
-        .expect("Inserting request should succeed");
-
-    let stored_request = session
-        .call::<u64, Option<Vec<u8>>>(LICENSE_CONTRACT_ID, "get_request", &0, POINT_LIMIT)
-        .expect("Querying request by position should succeed")
-        .data;
-    assert_eq!(stored_request, Some(request_blob.clone()));
-
-    let (feeder, receiver) = mpsc::channel();
-    let bh_range = 0..10000u64;
-    session
-        .feeder_call::<Range<u64>, ()>(
-            LICENSE_CONTRACT_ID,
-            "get_requests",
-            &bh_range,
-            u64::MAX,
-            feeder,
-        )
-        .expect("Querying requests should succeed")
-        .data;
-
-    let requests: Vec<(u64, Vec<u8>)> = receiver
-        .iter()
-        .map(|bytes| rkyv::from_bytes(&bytes).expect("Should return requests"))
-        .collect();
-    assert_eq!(requests, vec![(0, request_blob.clone())]);
-
-    assert!(
-        session
-            .call::<InsertRequestArg, ()>(
-                LICENSE_CONTRACT_ID,
-                "insert_request",
-                &insert_arg,
-                POINT_LIMIT,
-            )
-            .is_err(),
-        "Duplicate request payload should be rejected"
-    );
-
-    assert!(
-        session
-            .call::<InsertRequestArg, ()>(
-                LICENSE_CONTRACT_ID,
-                "insert_request",
-                &InsertRequestArg { request: vec![] },
-                POINT_LIMIT,
-            )
-            .is_err(),
-        "Empty request payload should be rejected"
-    );
-
-    assert!(
-        session
-            .call::<InsertRequestArg, ()>(
-                LICENSE_CONTRACT_ID,
-                "insert_request",
-                &InsertRequestArg {
-                    request: vec![0; MAX_REQUEST_BLOB_SIZE + 1]
-                },
-                POINT_LIMIT,
-            )
-            .is_err(),
-        "Oversized request payload should be rejected"
-    );
-
-    let state_info = session
-        .call::<(), ContractInfo>(LICENSE_CONTRACT_ID, "get_state_info", &(), POINT_LIMIT)
-        .expect("Get state info should succeed")
-        .data;
-    assert_eq!(state_info.requests, 1);
-    assert_eq!(state_info.licenses, 0);
-    assert_eq!(state_info.tree_len, 0);
-    assert_eq!(state_info.sessions, 0);
-    assert_eq!(state_info.accepted_roots, 0);
-
-    let legacy_info = session
-        .call::<(), (u32, u32, u32)>(LICENSE_CONTRACT_ID, "get_info", &(), POINT_LIMIT)
-        .expect("Get info should succeed")
-        .data;
-    assert_eq!(legacy_info, (0, 0, 0));
-}
-
-#[test]
 fn multiple_licenses_issue_get_merkle() {
     let rng = &mut StdRng::seed_from_u64(0xcafe);
     let mut session = initialize();
@@ -319,15 +205,14 @@ fn multiple_licenses_issue_get_merkle() {
 
     // license provider
     let sk_lp = SecretKey::random(rng);
-    let pk_lp = PublicKey::from(&sk_lp);
 
     let attr = JubJubScalar::from(USER_ATTRIBUTES);
 
     const NUM_LICENSES: usize = 4 + 1;
     for _ in 0..NUM_LICENSES {
-        let license = create_test_license(&attr, &sk_lp, &pk_lp, &sk_user, &pk_user, rng);
+        let license = create_test_license(&attr, &sk_lp, &pk_user, rng);
         let license_blob = rkyv::to_bytes::<_, 4096>(&license)
-            .expect("Request should serialize correctly")
+            .expect("License should serialize correctly")
             .to_vec();
 
         let issue_arg = issue_arg(&license, license_blob);
@@ -362,7 +247,7 @@ fn multiple_licenses_issue_get_merkle() {
     assert_eq!(
         pos_license_pairs.len(),
         NUM_LICENSES,
-        "Call to getting license requests should return licenses"
+        "Call to getting licenses should return licenses"
     );
 
     let owned_license = find_owned_license(&sk_user, &pos_license_pairs);
@@ -398,7 +283,6 @@ fn metadata_and_info_track_state() {
     assert_eq!(metadata.merkle_depth, circuit::DEPTH as u32);
     assert_eq!(metadata.root_history_size, 8);
     assert_eq!(metadata.public_inputs_len, PUBLIC_INPUTS_LEN as u32);
-    assert_eq!(metadata.max_request_blob_size, MAX_REQUEST_BLOB_SIZE as u32);
     assert_eq!(metadata.max_license_blob_size, MAX_LICENSE_BLOB_SIZE as u32);
 
     let initial_info = session
@@ -415,7 +299,6 @@ fn metadata_and_info_track_state() {
         .call::<(), ContractInfo>(LICENSE_CONTRACT_ID, "get_state_info", &(), POINT_LIMIT)
         .expect("Get state info should succeed")
         .data;
-    assert_eq!(initial_state_info.requests, 0);
     assert_eq!(initial_state_info.licenses, 0);
     assert_eq!(initial_state_info.tree_len, 0);
     assert_eq!(initial_state_info.sessions, 0);
@@ -436,9 +319,8 @@ fn metadata_and_info_track_state() {
     let sk_user = SecretKey::random(rng);
     let pk_user = PublicKey::from(&sk_user);
     let sk_lp = SecretKey::random(rng);
-    let pk_lp = PublicKey::from(&sk_lp);
     let attr = JubJubScalar::from(USER_ATTRIBUTES);
-    let license = create_test_license(&attr, &sk_lp, &pk_lp, &sk_user, &pk_user, rng);
+    let license = create_test_license(&attr, &sk_lp, &pk_user, rng);
     let license_blob = rkyv::to_bytes::<_, 4096>(&license)
         .expect("License should serialize correctly")
         .to_vec();
@@ -479,7 +361,6 @@ fn metadata_and_info_track_state() {
         .call::<(), ContractInfo>(LICENSE_CONTRACT_ID, "get_state_info", &(), POINT_LIMIT)
         .expect("Get state info should succeed")
         .data;
-    assert_eq!(issued_state_info.requests, 0);
     assert_eq!(issued_state_info.licenses, 1);
     assert_eq!(issued_state_info.tree_len, 1);
     assert_eq!(issued_state_info.sessions, 0);
@@ -557,9 +438,8 @@ fn issue_license_rejects_invalid_and_duplicate_public_keys() {
     let sk_user = SecretKey::random(rng);
     let pk_user = PublicKey::from(&sk_user);
     let sk_lp = SecretKey::random(rng);
-    let pk_lp = PublicKey::from(&sk_lp);
     let attr = JubJubScalar::from(USER_ATTRIBUTES);
-    let license = create_test_license(&attr, &sk_lp, &pk_lp, &sk_user, &pk_user, rng);
+    let license = create_test_license(&attr, &sk_lp, &pk_user, rng);
     let license_blob = rkyv::to_bytes::<_, 4096>(&license)
         .expect("License should serialize correctly")
         .to_vec();
@@ -676,19 +556,11 @@ fn use_license_get_session() {
     let sk_lp = SecretKey::random(rng);
     let pk_lp = PublicKey::from(&sk_lp);
 
-    let request =
-        Request::new(&sk_user, &pk_user, &pk_lp, rng).expect("Request correctly created.");
     let attr = JubJubScalar::from(USER_ATTRIBUTES);
-    let license = License::new(
-        &attr,
-        &sk_lp,
-        &LicenseOrigin::FromRequest(Box::new(request)),
-        rng,
-    )
-    .unwrap();
+    let license = create_test_license(&attr, &sk_lp, &pk_user, rng);
 
     let license_blob = rkyv::to_bytes::<_, 4096>(&license)
-        .expect("Request should serialize correctly")
+        .expect("License should serialize correctly")
         .to_vec();
 
     let issue_arg = issue_arg(&license, license_blob);
@@ -722,7 +594,7 @@ fn use_license_get_session() {
 
     assert!(
         !pos_license_pairs.is_empty(),
-        "Call to getting license requests should return licenses"
+        "Call to getting licenses should return licenses"
     );
 
     let owned_license = find_owned_license(&sk_user, &pos_license_pairs);

--- a/core/src/assets/license.rs
+++ b/core/src/assets/license.rs
@@ -33,7 +33,7 @@ const LIC_ENCRYPTION_SIZE: usize = LIC_PLAINTEXT_SIZE + ENCRYPTION_EXTRA_SIZE;
 
 /// Enumeration used to create new licenses
 pub enum LicenseOrigin {
-    /// From a [`Request`] sent on-chain
+    /// From a transport-neutral encrypted [`Request`] delivered to the LP.
     FromRequest(Box<Request>),
     /// From a [`PublicKey`] of a given user
     FromPublicKey(Box<PublicKey>),

--- a/core/src/assets/request.rs
+++ b/core/src/assets/request.rs
@@ -33,9 +33,8 @@ pub(crate) const REQ_PLAINTEXT_SIZE: usize = StealthAddress::SIZE
     + PublicKey::SIZE;
 const REQ_ENCRYPTION_SIZE: usize = REQ_PLAINTEXT_SIZE + ENCRYPTION_EXTRA_SIZE;
 
-/// The struct defining a Citadel request, a set of information that
-/// a user sends to the network to inform a LP that the user is
-/// requesting a license from them
+/// Transport-neutral encrypted request object delivered to an LP outside the
+/// base contract.
 #[cfg_attr(
     feature = "rkyv-impl",
     derive(Archive, Serialize, Deserialize),

--- a/docs/security.md
+++ b/docs/security.md
@@ -10,12 +10,12 @@ This document separates Citadel's threat model from the normative protocol speci
 
 Citadel has three cryptographic phases and one policy phase:
 
-1. **Request and issuance:** a user requests issuance to a license stealth address; an LP issues an encrypted license and registers a license leaf.
+1. **Request and issuance:** a user requests issuance to a license stealth address through a selected request transport, payment flow, or direct handoff; an LP issues an encrypted license and registers a license leaf.
 2. **License-use proof:** the user proves in zero knowledge that a hidden registered license exists, that the LP signed its attributes, and that the user knows the license secret key.
 3. **Session recording:** the contract verifies the proof, checks root acceptance, rejects duplicate `session_id`, and stores public session values.
 4. **Service authorization:** the SP verifies the cookie opening and applies its own issuer, attribute, challenge, replay, revocation, expiration, and account policy.
 
-The base Citadel protocol covers phases 1-3 and the cryptographic part of cookie opening in phase 4. It does not define universal service authorization.
+The base Citadel protocol covers the request object format, phases 2-3, and the cryptographic part of cookie opening in phase 4. It does not require request storage in the base contract and does not define universal request transport or service authorization.
 
 ## 2. Assets
 
@@ -27,26 +27,26 @@ Citadel protects or depends on the following assets:
 - SP service keys and service-policy state;
 - signed attributes and eligibility claims;
 - attribute blinding randomness;
-- encrypted request payloads and request metadata;
+- encrypted request payloads, request transport metadata, and payment/request binding data;
 - encrypted license payloads and license metadata;
 - session cookies and cookie openings;
 - Merkle tree state, accepted roots, and Merkle openings;
 - contract verifier key and circuit definition;
 - deployment metadata, domain constants, generator set, and public-input order;
 - privacy of which issued license was used in a session;
-- availability of request discovery, license registry, session registry, indexers, and SP verification endpoints.
+- availability of request delivery transports, license registry, session registry, indexers, and SP verification endpoints.
 
 ## 3. Adversaries
 
 ### 3.1 Passive Chain Observer
 
-Sees all public contract data, including encrypted request blobs, encrypted license blobs, license stealth addresses, license hashes, roots, session public inputs, transaction timing, and fees.
+Sees all public contract data, including encrypted license blobs, license stealth addresses, license hashes, roots, session public inputs, transaction timing, and fees. If the selected request transport publishes requests, request references, or payment memos on-chain, the observer also sees those payloads and their timing.
 
 Goals may include linking issuance to session use, identifying the LP or SP behind a session, inferring attributes or challenges, or tracking users across sessions.
 
 ### 3.2 Network Observer Or Active Network Attacker
 
-Sees or modifies off-chain communication unless the channel is authenticated and confidential. May attempt cookie theft, replay, request correlation, traffic analysis, downgrade attacks, or SP endpoint impersonation.
+Sees or modifies off-chain communication unless the channel is authenticated and confidential. May attempt request substitution, request correlation, payment/request misbinding, cookie theft, replay, traffic analysis, downgrade attacks, or SP endpoint impersonation.
 
 ### 3.3 Malicious User
 
@@ -76,15 +76,15 @@ Users must treat disclosed attributes and cookies as data intentionally revealed
 
 ### 3.6 LP/SP Collusion
 
-Combines issuance records, unique attributes, disclosed `attr_data`, request timing, service timing, payments, network metadata, account identifiers, and direct-issuance data to deanonymize users.
+Combines issuance records, unique attributes, disclosed `attr_data`, request timing, payment memo metadata, service timing, payments, network metadata, account identifiers, and direct-issuance data to deanonymize users.
 
 Citadel's on-chain zero knowledge does not prevent correlation through data intentionally disclosed to LPs or SPs or through external metadata.
 
-### 3.7 State Spammer
+### 3.7 State Or Request-Transport Spammer
 
-Attempts to fill request storage, exhaust license tree capacity, increase indexer load, force LPs to scan noise, store bogus license leaves, or induce expensive proof verification.
+Attempts to exhaust license tree capacity, increase indexer load, store bogus license leaves, induce expensive proof verification, or flood LP request transports with empty, duplicate, huge, or malformed requests. If a deployment adds an on-chain request-availability extension or uses payment memos as request transport, the attacker may also try to create persistent request metadata or force LPs to scan noisy payment/request streams.
 
-Gas is an economic deterrent but not a cryptographic defense. Gas-only spam control is a deployment choice and must be justified against persistent storage cost, finite tree capacity, low-fee environments, subsidized attackers, and off-chain scanning costs.
+Gas is an economic deterrent but not a cryptographic defense. Gas-only spam control is a deployment choice and must be justified against persistent storage cost, finite tree capacity, low-fee environments, subsidized attackers, and off-chain scanning costs. Off-chain request transports require their own admission controls, payment thresholds, rate limits, authentication, or abuse handling.
 
 ### 3.8 Malicious Or Curious Proof Helper
 
@@ -99,7 +99,7 @@ Obtains user, LP, SP, transport, or service-channel keys. Consequences depend on
 - user wallet key can derive future or stored license secrets depending on wallet design;
 - license secret key can open sessions for that license under accepted challenges;
 - LP signing key can issue licenses trusted by SPs until revoked by policy;
-- SP channel or server keys can expose cookies or allow service impersonation;
+- request transport, payment service, SP channel, or server keys can expose requests, cookies, or allow service impersonation;
 - deployment or verifier-key compromise invalidates protocol assumptions.
 
 ### 3.10 Chain Reorganization Or State-Availability Adversary
@@ -116,6 +116,7 @@ Citadel assumes:
 - all external encodings are canonical and validated before cryptographic use;
 - wallets and services use fresh CSPRNG randomness or safe deterministic nonce derivation;
 - contract state is read from authenticated sources with the deployment's finality policy;
+- request transports and payment flows provide the authenticity, confidentiality, finality, and availability claimed by the selected deployment or LP profile;
 - SPs correctly enforce their own policy profiles;
 - LPs are trusted only for claims under keys that the SP explicitly accepts;
 - users understand that disclosed cookies are bearer credentials unless the SP profile adds binding.
@@ -176,7 +177,7 @@ This goal is conditional on the SP actually performing all required policy check
 
 ### 5.9 Request And License Confidentiality
 
-Encrypted request and license payloads should reveal no plaintext to unauthorized parties under the AEAD, KDF, DHKE, and stealth-address assumptions. Visible metadata such as insertion time, payload size, and target LP scanning behavior is not hidden by the base protocol.
+Encrypted request objects and license payloads should reveal no plaintext to unauthorized parties under the AEAD, KDF, DHKE, and stealth-address assumptions. Request metadata leakage is transport-dependent: payment memo timing, payload size, request references, network metadata, direct handoff context, and target LP processing behavior are not hidden by the base protocol. If a user intentionally uses public-address or public-request issuance, the disclosed fields are outside this confidentiality goal.
 
 ### 5.10 Deployment Separation
 
@@ -193,8 +194,8 @@ Citadel does not by itself guarantee:
 - resistance to LP/SP collusion through disclosed attributes or metadata;
 - resistance to malicious LPs signing false claims;
 - resistance to voluntary sharing or sale of `lsk`;
-- availability of request scanning or license registry capacity;
-- privacy against network, payment, browser, account, or device fingerprinting;
+- availability of request delivery transports or license registry capacity;
+- privacy against network, payment, payment-memo, browser, account, or device fingerprinting;
 - policy safety when the SP accepts arbitrary user-chosen `c`;
 - protection after LP signing-key compromise unless the SP updates trust policy.
 
@@ -202,7 +203,7 @@ Citadel does not by itself guarantee:
 
 | Area | Attack | Primary mitigation |
 | --- | --- | --- |
-| Request registry | Empty, duplicate, huge, or high-volume request spam | Gas or fees only if documented as sufficient; otherwise size limits, duplicate checks, retention policy, allow lists, rate limits, deposits, or pruning |
+| Request transport or optional request registry | Empty, duplicate, huge, malformed, misbound, or high-volume request spam | Transport-specific admission policy, memo size limits, request hashes, payment/invoice binding, replay checks, authentication, rate limits, minimum payments, deposits, pruning, or gas/fees only when documented as sufficient |
 | License registry | Tree capacity exhaustion or bogus leaves | Issuer allow list, insertion fees, staking, duplicate policy, explicit tree-full behavior |
 | Proof verification | Expensive invalid proofs | Charge gas before verification, cap proof size, use efficient verifier, rate-limit at relayers or frontends |
 | Roots | Stale or unaccepted roots | Contract root acceptance check, bounded root history, SP freshness rule, finality policy |
@@ -215,19 +216,21 @@ Citadel does not by itself guarantee:
 | Privacy | LP/SP collusion on `attr_data` or metadata | Selective disclosure, coarse attributes, timing mitigation, avoid direct issuance when unlinkability matters |
 | Proof helpers | Metadata leakage or attempted proof mutation | Do not reveal `lsk`; double-key authorization binds exact public tuple; local proving for sensitive cases |
 
-## 8. Gas And Contract Spam Analysis
+## 8. Gas, Contract Spam, And Request-Transport Analysis
 
 Gas consumption helps because attackers must pay for transactions, proof verification, and state writes. However, gas does not automatically solve spam for Citadel because:
 
 - the license tree has finite capacity and can be filled by a well-funded or subsidized actor if insertion is permissionless;
 - some chains underprice long-term state growth relative to one-time gas;
-- request spam imposes off-chain LP scanning and indexer costs that may not be paid to the LP;
 - gas prices vary over time and may become cheap enough for griefing;
 - a deployment may subsidize users or use relayers, weakening the deterrent;
-- exact duplicate rejection does not stop distinct encrypted garbage payloads;
 - proof verification gas prices the caller's transaction, but does not protect SPs from off-chain verification attempts or cookie spam.
 
-Therefore, gas can be accepted as the deployment's spam-control policy only if the deployment explicitly says so and its economics match the expected threat. Otherwise, the protocol should include explicit controls such as insertion fees, maximum blob sizes, pruning, allow-listed issuers, deposits, rate limits, or application-level request admission.
+Removing request storage from the base contract eliminates the base protocol's persistent request-storage spam vector and removes the need for every LP to scan a canonical contract request queue. It does not eliminate request abuse. The selected request transport can still be spammed, especially if it accepts unauthenticated messages, large memos, cheap payment metadata, public request references, or subsidized submissions.
+
+For payment-memo request transport, the LP should define minimum payment thresholds, invoice matching, memo size limits, request hash or reference rules, finality requirements, replay checks, and refund or failure behavior. For off-chain or in-person transport, the LP should define authentication, rate limits, queue limits, retention, and abuse handling.
+
+Gas can be accepted as the deployment's spam-control policy only for the contract resources it actually prices, and only if the deployment explicitly says so and its economics match the expected threat. License insertion, proof verification, optional request availability extensions, payment-memo scanning, and off-chain request intake each need their own admission analysis.
 
 ## 9. Proof Obligations For Upcoming Security Work
 
@@ -272,9 +275,10 @@ Before claiming security for a deployment, reviewers should check:
 - all points are subgroup-checked and identity-rejected where required;
 - scalar range checks are correct if `F_c` and `F_s` differ;
 - Merkle tree arity, depth, empty leaves, and path order are identical across contract, circuit, and clients;
-- request and license encryption uses context-bound AEAD associated data;
-- request and license blob sizes are bounded;
-- registry insertion policy addresses spam and tree capacity;
+- request-object encryption, when used, and license encryption use context-bound AEAD associated data;
+- request payload, payment memo, request reference, and license blob sizes are bounded by the selected transports;
+- license registry insertion policy addresses spam and tree capacity;
+- request transports define replay handling, payment binding, finality, retention, and abuse controls;
 - SP profiles reject arbitrary challenge values unless unlimited reuse is intended;
 - cookie verification includes policy ID, cookie mode, root freshness, issuer trust, and replay rules;
 - expiration and revocation are either enforced or explicitly not supported;

--- a/docs/specs.md
+++ b/docs/specs.md
@@ -27,7 +27,7 @@ Citadel also does not automatically provide:
 - replay protection for a disclosed cookie;
 - revocation or current-validity checks beyond membership in an accepted root;
 - issuer-verifier unlinkability when attributes are unique, when timing or network metadata is identifying, or when the LP and SP collude;
-- availability protection for request discovery, registry storage, or SP service endpoints;
+- availability protection for request delivery, registry storage, or SP service endpoints;
 - authorization for every service that accepts Citadel proofs.
 
 The standalone [threat model](security.md) defines adversaries, assets, security goals, residual risks, and proof obligations. The protocol specification keeps only the normative mechanics needed for interoperable implementations.
@@ -39,7 +39,7 @@ The standalone [threat model](security.md) defines adversaries, assets, security
 - **User:** controls a wallet key pair, requests licenses, owns license secret keys, opens sessions, and sends cookies to SPs.
 - **License Provider (LP):** evaluates requests, defines signed attributes, signs licenses, and publishes encrypted licenses.
 - **Service Provider (SP):** publishes a policy profile, verifies cookies, and grants or denies service.
-- **Contract:** stores encrypted request and license blobs, stores issued license commitments, maintains accepted Merkle roots, verifies license-use proofs, rejects duplicate session IDs, and stores public session records.
+- **Contract:** stores encrypted license blobs, stores issued license commitments, maintains accepted Merkle roots, verifies license-use proofs, rejects duplicate session IDs, and stores public session records. The base contract does not store issuance requests unless a deployment adds an explicit request-availability extension.
 - **Validators:** execute the contract and verify proofs according to the deployed verifier key.
 - **Optional proof helper:** may help generate a proof, but MUST NOT receive the user's license secret key.
 
@@ -102,7 +102,7 @@ Each Citadel deployment MUST define:
 - compact hash-context derivation;
 - Merkle tree parameters;
 - root acceptance policy;
-- request insertion, retention, duplicate, size-limit, fee, and spam-control policy;
+- request transport, admission, replay, duplicate, size-limit, retention, payment-binding, and spam-control policy, if request objects are used;
 - license issuance access policy;
 - duplicate `license_hash` policy;
 - tree-full behavior;
@@ -193,7 +193,7 @@ For structured data, implementations MUST:
 - use versioned canonical serialization;
 - avoid ad hoc concatenation without lengths or type tags;
 - bind the `deployment_id`, schema ID, policy ID, and cookie mode where relevant;
-- enforce maximum payload sizes for contract-stored request and license blobs;
+- enforce maximum payload sizes for request payloads and contract-stored license blobs;
 - reject unknown critical fields unless the object version explicitly permits forward-compatible extension.
 
 The same validation rules apply to requests, licenses, public inputs, cookies, LP keys, SP keys, Merkle openings, signatures, and off-chain predicate proof inputs.
@@ -307,7 +307,7 @@ Citadel uses:
 
 ### 5.5 Encryption And KDF
 
-Encrypted request and license payloads MUST use authenticated encryption. The concrete AEAD MAY be supplied by the deployment, but it MUST provide confidentiality, integrity, explicit failure on tampering, unambiguous serialization, and nonce-misuse resistance appropriate to the chosen mode.
+Encrypted request objects and license payloads MUST use authenticated encryption. The concrete AEAD MAY be supplied by the deployment, but it MUST provide confidentiality, integrity, explicit failure on tampering, unambiguous serialization, and nonce-misuse resistance appropriate to the chosen mode.
 
 Every encryption key MUST be derived with a domain-separated KDF that includes:
 
@@ -323,7 +323,7 @@ AEAD nonces or salts MUST be unique for a given encryption key unless the chosen
 
 Decryption failure MUST be treated as authentication failure. Callers MUST NOT use unauthenticated plaintext.
 
-License encryption key material sent inside a request MUST NOT be the license secret key and MUST NOT allow recovery of the license secret key. It MAY be derived deterministically from `lsk` through a one-way KDF with a license-encryption domain, or it MAY be generated independently and stored by the user. The LP may learn the license encryption key material, but must not learn `lsk`.
+License encryption key material sent inside a request MUST NOT be the license secret key and MUST NOT allow recovery of the license secret key. It MAY be derived deterministically from `lsk` through a one-way KDF with a license-encryption domain, or it MAY be generated independently and stored by the user. The LP may learn the license encryption key material, but must not learn `lsk`. In direct issuance without a request object, the deployment MUST define an equivalent license-encryption key derivation, typically from the DH shared secret used to create the license stealth address.
 
 ### 5.6 Merkle Tree
 
@@ -363,11 +363,11 @@ The base circuit is verified by the deployed PlonK verifier key. The verifier ke
 
 ## 6. Data Objects
 
-### 6.1 Request
+### 6.1 Issuance Request
 
-A request asks an LP to issue a license to a user-owned license stealth address.
+An issuance request is a transport-neutral object asking an LP to issue a license to a user-controlled license destination. It is not part of the base contract state and is not consumed by the license-use circuit. A deployment MAY use this object for private request-based issuance, or it MAY use direct issuance without an encrypted request when the relevant privacy tradeoffs are acceptable.
 
-Fields:
+Fields for the encrypted request object:
 
 - `version`
 - `deployment_id`
@@ -378,7 +378,7 @@ Where:
 
 - `lsa` is the license stealth address where the license will be issued.
 - `k_lic_enc` is license encryption key material known to the user and disclosed to the LP only inside the encrypted request.
-- `request_context` includes `deployment_id`, intended LP key or LP identifier, object version, requested schema or policy information, and any LP-required application metadata.
+- `request_context` includes `deployment_id`, intended LP key or LP identifier, object version, requested schema or policy information, any LP-required application metadata, and any transport binding required by the deployment profile. Transport binding MAY include an invoice ID, payment reference, transaction hash commitment, expected payment recipient, payment asset, payment amount, request expiry, or off-chain authorization data.
 
 The request ID is:
 
@@ -386,11 +386,13 @@ The request ID is:
 
 LPs MUST maintain a replay policy for request IDs and license stealth addresses. They MUST NOT issue duplicate licenses for the same `lsa` unless duplicate issuance is an explicit application requirement.
 
-After decryption, the LP MUST check that `request_context` matches the visible request fields, intended LP key, `deployment_id`, and deployment profile. A mismatch invalidates the request.
+After decryption, the LP MUST check that `request_context` matches the visible request fields, intended LP key, `deployment_id`, deployment profile, and selected request transport. A mismatch invalidates the request.
 
-The base deployment stores encrypted request blobs in the contract. The contract is not expected to decrypt or semantically validate requests, but it MUST provide a stable insertion and retrieval interface so LPs can discover requests from authenticated contract state.
+Request delivery is selected by the deployment or application profile. Acceptable transports include an authenticated off-chain channel, an in-person handoff such as a QR code, a payment transaction memo or equivalent transaction metadata field, or an optional authenticated availability layer. The base Citadel contract MUST NOT be assumed to store or make requests available. If a deployment adds a contract-backed request registry, it is an extension and MUST specify insertion authorization, retention, retrieval, payload size limits, duplicate handling, fees, and spam policy.
 
-Request insertion policy is a deployment parameter. Gas consumption MAY be the primary spam control only if the deployment explicitly documents that gas and any additional insertion fees adequately price persistent storage, index growth, LP scanning burden, and state availability costs. Otherwise, deployments SHOULD add at least one of: maximum payload sizes, per-request fees, deposits, rate limits, allow lists, pruning/retention limits, or application-level admission controls. The contract SHOULD reject empty request payloads and exact duplicate request blobs unless the deployment profile explicitly allows them.
+If a request is carried in payment transaction metadata, the request payload MUST be encrypted unless public-address or public-request disclosure is an explicit application choice. The LP MUST verify payment finality, payment recipient, asset, amount, memo or payload size limits, and the binding between the payment or invoice and `request_id` or `lsa` before issuance. If the transaction metadata cannot fit the complete request, it MAY carry a request reference plus a cryptographic hash of the referenced request object. The referenced payload MUST be fetched from an authenticated source or verified against the hash before use.
+
+If privacy is not required, the user MAY provide `lsa` and license encryption material through an authenticated channel, or MAY provide a static public address or direct-issuance target as specified in Section 8.4. Public-address issuance is a lower-privacy mode because the LP can associate the issued license with the disclosed address, account, payment, or in-person identity.
 
 ### 6.2 License
 
@@ -477,13 +479,13 @@ Selective-disclosure cookies and proofs MUST be bound to `session_id`, `deployme
 
 ## 7. Contract State, Registry Policy, And Interfaces
 
-### 7.1 Request Registry
+### 7.1 Request Transport
 
-The request registry stores encrypted user-to-LP request blobs for LP discovery. Each deployment MUST define who may insert requests, how request storage spam is controlled, maximum payload size, duplicate handling, how long clients are expected to scan historical requests, and whether request data is retained in contract state, events, or another authenticated availability layer.
+The base contract has no request registry. Request delivery is an application or deployment transport, not a cryptographic requirement of the license-use circuit. Each deployment or LP profile that supports request-based issuance MUST define accepted request transports, whether requests are encrypted or intentionally public, maximum payload or memo sizes, replay and duplicate policy, payment or invoice binding, finality requirements, retention and discovery expectations, and admission or spam control.
 
-Successful request insertion does not mean an LP has accepted, decrypted, or even seen the request. LPs MUST still enforce their own `request_id`, `lsa`, eligibility, payment, replay, issuance, and business policies after decryption.
+Successful request delivery, memo inclusion, or payment submission does not mean an LP has accepted, decrypted, or even seen the request. LPs MUST still enforce their own `request_id`, `lsa`, eligibility, payment, replay, issuance, and business policies after decryption or direct handoff.
 
-Gas is an economic deterrent, not a cryptographic invariant. Gas can be sufficient for a deployment only when it prices all relevant costs and when the deployment accepts that well-funded actors may still insert many requests. If request spam affects LP scanning, state size, user UX, or application availability, the deployment SHOULD add explicit non-gas controls.
+A deployment MAY add a contract-backed request availability extension. Such an extension is outside the base contract interface and MUST specify its own insertion authorization, retrieval API, retention policy, size limits, duplicate handling, fees, and spam controls. Gas is an economic deterrent, not a cryptographic invariant; it is sufficient only if the deployment explicitly accepts the economics and operational cost assumptions.
 
 ### 7.2 License Registry
 
@@ -507,9 +509,6 @@ SP trust in LPs is separate from contract insertion permission. A license leaf b
 
 The base contract interface for wallets, LPs, SPs, and web clients SHOULD expose at least:
 
-- `insert_request`: store an encrypted request blob.
-- `get_requests`: stream stored requests by block-height range or indexed range.
-- `get_request`: fetch a request by request position.
 - `issue_license`: store an encrypted license blob and register its license leaf.
 - `get_licenses`: stream stored licenses by block-height range or indexed range.
 - `get_license`: fetch a license by license tree position.
@@ -518,7 +517,9 @@ The base contract interface for wallets, LPs, SPs, and web clients SHOULD expose
 - `get_session`: fetch a session by `session_id`.
 - `get_metadata`: fetch deployment metadata.
 - `get_current_root` and `get_accepted_roots`: inspect root state.
-- `get_state_info`: fetch named request, license, tree, session, and root counters.
+- `get_state_info`: fetch named license, tree, session, and root counters.
+
+A request-availability extension MAY expose `insert_request`, `get_requests`, or `get_request`, but those calls are not part of the base Citadel contract interface.
 
 Legacy or constrained clients MAY expose smaller compatibility queries, such as tuple-shaped `get_info`, but new clients SHOULD prefer named return types to avoid positional ambiguity.
 
@@ -526,7 +527,7 @@ Legacy or constrained clients MAY expose smaller compatibility queries, such as 
 
 ### 8.1 User Requests A License
 
-The user creates a license destination and submits an encrypted request for LP discovery.
+The user creates a license destination and delivers an issuance request to the LP through the request transport selected by the deployment, LP, payment flow, or application profile.
 
 1. Generate a fresh license stealth address for the user:
 
@@ -560,17 +561,24 @@ The user creates a license destination and submits an encrypted request for LP d
 
    `k_req = KDF[CITADEL_REQUEST_KEY_V1](K_req, rsa, pk_lp, deployment_id, salt_req)`
 
-6. Encrypt `lsa || k_lic_enc || request_context` with AEAD under `k_req`, using associated data that includes the visible request fields.
+6. Encrypt `lsa || k_lic_enc || request_context` with AEAD under `k_req`, using associated data that includes the visible request fields and the transport-binding fields required by the deployment profile.
 
-7. Submit `Request { version, deployment_id, rsa, enc }` through `insert_request`.
+7. Deliver `Request { version, deployment_id, rsa, enc }` to the LP through one of the selected request transports, such as:
 
-The request is public contract state. It MUST NOT reveal the user's static key, license secret key, or license attributes.
+   - an authenticated and confidential off-chain channel;
+   - an in-person handoff or QR code;
+   - a payment transaction memo or equivalent transaction metadata field;
+   - an authenticated off-chain availability layer or optional contract-backed request extension.
+
+If the request is embedded in transaction metadata, the user MUST respect the transport's size and encoding limits. The user MUST NOT place `lsk` in the request or memo. The user SHOULD send an encrypted request object, or a request reference plus a hash, unless public-address or public-request disclosure is an explicit application choice.
+
+The request is not base contract state by default. It MUST NOT reveal the user's static key, license secret key, or license attributes unless the user intentionally selects a public or direct-issuance mode.
 
 ### 8.2 LP Processes A Request
 
-The LP scans contract request payloads with `get_requests`, optionally using `get_request` for direct lookup if it already knows a request position. Application channels MAY notify the LP that a request was inserted, but the LP MUST treat the contract request registry or the deployment's declared authenticated request transport as the canonical source.
+The LP obtains candidate requests from the selected request transport. For payment-memo issuance, the LP MUST verify payment finality, payment recipient, asset, amount, memo or reference integrity, and binding to the relevant invoice, `request_id`, or `lsa` before issuance. For off-chain or in-person delivery, the LP MUST apply the authentication, confidentiality, and admission rules required by its profile.
 
-For each candidate request:
+For each candidate encrypted request:
 
 1. Validate all encodings and size limits.
 2. Compute `K_req = sk_lp.a * R_req`.
@@ -582,14 +590,14 @@ For each candidate request:
 5. Attempt AEAD decryption. Failure means the request is not accepted.
 6. Recover `lsa`, `k_lic_enc`, and request context.
 7. Check the request replay policy.
-8. Check that `deployment_id`, intended LP key, schema requests, and visible request fields match the decrypted context.
+8. Check that `deployment_id`, intended LP key, schema requests, visible request fields, and transport-binding fields match the decrypted context.
 9. Evaluate any off-chain identity, payment, KYC, authorization, or business requirements.
 
-The recovered `lsa` tells the LP where to issue the license. It does not reveal the user's static public key in the request path.
+The recovered `lsa` tells the LP where to issue the license. It does not reveal the user's static public key in the encrypted request path. Transport metadata, payment metadata, or application identity checks may still reveal the user to the LP.
 
 ### 8.3 LP Issues A License
 
-If the request is accepted, the LP creates a license.
+If the request or direct-issuance input is accepted, the LP creates a license.
 
 1. Define the attribute schema and canonical attributes.
 2. Compute schema-scoped `attr_data` as specified by the schema. See Section 11.
@@ -601,7 +609,7 @@ If the request is accepted, the LP creates a license.
 
    `sig_lic = SchnorrSign(sk_lp.a, msg_lic)`
 
-5. Encrypt `sig_lic || attr_data || license_context` under `k_lic_enc` with AEAD and context-bound associated data.
+5. Encrypt `sig_lic || attr_data || license_context` under `k_lic_enc` or the deployment-defined direct-issuance license encryption key with AEAD and context-bound associated data.
 
 6. Publish `License { version, deployment_id, lsa, enc }`.
 
@@ -619,9 +627,11 @@ The LP MUST NOT reuse the same license stealth address for independent licenses 
 
 ### 8.4 Direct Issuance
 
-A deployment MAY support direct issuance to a user's public key instead of a request. Direct issuance derives the license destination and encryption material using DHKE with the user's public key or another deployment-defined authenticated channel.
+A deployment MAY support direct issuance without an encrypted request object. In direct issuance, the user provides a static public key, account identifier, `lsa`, or another deployment-defined issuance target to the LP through a payment flow, service flow, or in-person process.
 
-Direct issuance is a lower-privacy mode. The LP can know the user's static public key or application identity when issuing the license. Wallets and SPs SHOULD treat direct-issued licenses differently if issuer-verifier unlinkability matters.
+When the user provides a static public key, the LP derives the license destination and license encryption material using DHKE with that public key. When the user provides an `lsa`, the user MUST also provide a license encryption mechanism that lets the LP encrypt the license without learning `lsk`. In all cases, the license encryption method MUST be deployment-defined and context-bound.
+
+Direct issuance is a lower-privacy mode. The LP can know the user's static public key, account, payment identity, or in-person identity when issuing the license. Wallets and SPs SHOULD treat direct-issued licenses differently if issuer-verifier unlinkability matters.
 
 ### 8.5 User Fetches A License
 
@@ -955,7 +965,7 @@ For long-lived sessions, the SP SHOULD bind access to an authenticated account o
 
 On-chain observers see:
 
-- encrypted request blobs and request insertion timing;
+- request payloads, payment memos, transaction notes, or request references when the selected transport publishes them on-chain;
 - encrypted license blobs;
 - license stealth addresses;
 - license hashes;
@@ -977,13 +987,13 @@ These privacy properties rely on fresh randomness, valid commitments, PlonK zero
 
 ### 13.2 LP And SP Knowledge
 
-The LP learns whatever the user discloses during license request review and the attributes it signs. In request-based issuance, the LP does not learn the user's static public key from the cryptographic request alone.
+The LP learns whatever the user discloses during license request review, payment processing, direct handoff, and the attributes it signs. In encrypted request-based issuance, the LP does not learn the user's static public key from the cryptographic request alone unless the request context, payment channel, network metadata, or business process reveals it.
 
 The SP learns whatever is disclosed by the selected cookie mode and policy proof. In base mode, it learns `attr_data` or enough data to interpret it.
 
 If the LP also knows that same `attr_data`, the value itself can link issuance and service use under LP/SP collusion.
 
-If the LP and SP collude, unique attributes, request metadata, timing, payments, network metadata, or direct issuance can link issuance to service use. Citadel does not prevent correlation through non-cryptographic side channels.
+If the LP and SP collude, unique attributes, request metadata, payment memo metadata, timing, payments, network metadata, or direct issuance can link issuance to service use. Citadel does not prevent correlation through non-cryptographic side channels.
 
 ### 13.3 Proof Helpers
 
@@ -1020,9 +1030,9 @@ A deployment conforms to this specification only if:
 - every Poseidon, KDF, and signature context is domain-separated;
 - every external point and scalar is canonically validated;
 - circuit witness points are constrained to valid non-identity subgroup points;
-- request and license encryption is authenticated and context-bound;
-- request insertion, retrieval, retention, duplicate handling, size limits, fees, and spam controls are explicit;
-- gas-only spam control, if used, is explicitly justified by deployment economics and operational cost assumptions;
+- request-object encryption, when used, and license encryption are authenticated and context-bound;
+- request transport, replay handling, payment binding, retention, duplicate handling, size limits, fees, and spam controls are explicit when request objects are used;
+- gas-only spam control, if used for license insertion or an optional request-availability extension, is explicitly justified by deployment economics and operational cost assumptions;
 - license hashes are derived from visible license public key data;
 - issuance access and tree-capacity behavior are explicit;
 - duplicate `license_hash` handling is explicit;
@@ -1044,10 +1054,10 @@ A deployment conforms to this specification only if:
 
 For an academic or prototype deployment:
 
-- use request-based issuance;
-- expose contract-backed request discovery for LPs;
-- set maximum request and license blob sizes;
-- define request spam limits, fees, or a clear gas-only rationale;
+- use encrypted request-based issuance unless direct issuance privacy tradeoffs are acceptable;
+- deliver requests through the payment, service, or authenticated off-chain channel instead of the base contract;
+- set maximum request payload, payment-memo, request-reference, and license blob sizes;
+- define request-transport admission, replay, payment-binding, and spam controls;
 - allow-list LP issuers or require fees for registry insertion;
 - keep a bounded root history;
 - use base disclosure only for non-sensitive attributes;


### PR DESCRIPTION
This PR updates the specs so that the Request is no longer part of the contract, and updates the implementation accordingly.