### PR TITLE
Switch to dusk_curves

### DIFF
--- a/.github/workflows/dusk_ci.yml
+++ b/.github/workflows/dusk_ci.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: dsherret/rust-toolchain-file@v1
       - uses: Swatinem/rust-cache@v2
       - run: cargo fmt --check
-      - run: cargo clippy -p zk-citadel-wallet --all-targets -- -D warnings
+      - run: cargo clippy -p zk-citadel-wallet --all-targets --no-default-features --features bls-backend-blst -- -D warnings
       - run: make test-wallet
 
   dusk_analyzer:
@@ -42,4 +42,4 @@ jobs:
       - uses: dsherret/rust-toolchain-file@v1
       - run: make test-core
       - run: make test-contract
-      - run: RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --features zk
+      - run: RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --no-default-features --features rkyv-impl,std,zk,contract,bls-backend-blst

--- a/.github/workflows/dusk_ci.yml
+++ b/.github/workflows/dusk_ci.yml
@@ -12,7 +12,7 @@ jobs:
     uses: dusk-network/.github/.github/workflows/code-analysis.yml@main
     with:
       clippy_default: false
-      clippy_args: --release --no-default-features --features rkyv-impl,std,zk,contract,bls-backend-blst -- -D warnings
+      clippy_args: --release --features zk,bls-backend-blst -- -D warnings
 
   wallet_code_analysis:
     name: Wallet Code Analysis
@@ -21,8 +21,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dsherret/rust-toolchain-file@v1
       - uses: Swatinem/rust-cache@v2
-      - run: cargo fmt --check
-      - run: cargo clippy -p zk-citadel-wallet --all-targets --no-default-features --features bls-backend-blst -- -D warnings
+      - run: cargo fmt --all --check
+      - run: cargo clippy -p zk-citadel-wallet --all-targets --features bls-backend-blst -- -D warnings
       - run: make test-wallet
 
   dusk_analyzer:
@@ -45,4 +45,4 @@ jobs:
       - uses: dsherret/rust-toolchain-file@v1
       - run: make test-core
       - run: make test-contract
-      - run: RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --no-default-features --features rkyv-impl,std,zk,contract,bls-backend-blst
+      - run: RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --features zk,bls-backend-blst

--- a/.github/workflows/dusk_ci.yml
+++ b/.github/workflows/dusk_ci.yml
@@ -10,6 +10,9 @@ jobs:
   code_analysis:
     name: Code Analysis
     uses: dusk-network/.github/.github/workflows/code-analysis.yml@main
+    with:
+      clippy_default: false
+      clippy_args: --release --no-default-features --features rkyv-impl,std,zk,contract,bls-backend-blst -- -D warnings
 
   wallet_code_analysis:
     name: Wallet Code Analysis

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,40 +82,49 @@ make bench
 make run-wallet
 ```
 
-All Makefile build, test, benchmark, and wallet targets use release mode. ZK targets keep Cargo default features enabled while adding `zk`, so `dusk-plonk/std` remains enabled and PlonK can use its parallel `std`/rayon path.
+All Makefile build, test, benchmark, and wallet targets use release mode. The build, wallet, test, and benchmark targets select `bls-backend-blst` unless `BLS_BACKEND` is explicitly overridden for a build or wallet run. ZK targets explicitly enable `std`, so `dusk-plonk/std` remains enabled.
 
 Target details:
 
 ```sh
 make contract                         # builds release artifacts and wasm
+make contract BLS_BACKEND=bls-backend-dusk  # explicitly use the Dusk backend
 make test-contract                    # runs make contract, then contract VM tests
 make test-core                        # core tests with zk enabled
 make test-wallet                      # wallet tests in release mode
 make bench                            # core benchmarks with zk enabled
 make bench BENCH_ARGS=--no-run        # compile benchmarks without running them
 make run-wallet WALLET_ARGS="--help"  # run the wallet in release mode
+make run-wallet BLS_BACKEND=bls-backend-dusk WALLET_ARGS="--help"
 ```
 
-Documentation and wallet analysis/publishing checks:
+Documentation and wallet analysis checks:
 
 ```sh
-RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --features zk
+RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --no-default-features --features rkyv-impl,std,zk,contract,bls-backend-blst
 cargo fmt --check
-cargo clippy -p zk-citadel-wallet --all-targets -- -D warnings
+cargo clippy -p zk-citadel-wallet --all-targets --no-default-features --features bls-backend-blst -- -D warnings
 make test-wallet
-cargo package -p zk-citadel-wallet --allow-dirty
 ```
 
 Notes:
+- The core, contract, and wallet Cargo features deliberately do not select a
+  BLS backend by default. Direct Cargo invocations must enable exactly one of
+  `bls-backend-blst` or `bls-backend-dusk`; the Makefile selects BLST by
+  default.
 - Always run repository tests with `--release`. The PlonK prover path runs in
   parallel and is much faster in release mode; debug-mode ZK tests can appear to
   hang for a long time.
 - Contract tests include `target/prover`, `target/verifier`, and the wasm artifact, so run `make contract` before `contract` VM tests or use `make test-contract`. The contract crate does not define a `zk` feature; do not pass `--features zk` to `cargo test` from `contract/`.
-- ZK tests should run in release mode with default features so `dusk-plonk/std` remains enabled. Avoid adding the slow non-default-feature ZK test path to routine docs or CI unless a specific no-std regression needs investigation.
+- ZK tests should run in release mode through the Makefile so `std` and the BLST backend are selected explicitly. Avoid adding the slow no-std ZK test path to routine docs or CI unless a specific no-std regression needs investigation.
 - `contract/build.rs` first tries to download the trusted setup from `https://nodes.dusk.network/trusted-setup` and verify its SHA-256 hash. If download fails it generates local setup material and warns that this is unsafe for real use. Do not present fallback-generated keys as deployment-ready.
 - `target/` artifacts are generated and ignored. Do not commit proving/verifier keys or wasm build outputs unless the repository policy changes.
 - The wallet defaults `deploy` to `target/wasm32-unknown-unknown/release/license_contract.wasm` and `use-license` to `target/prover`, relative to the current working directory. Override with `--code` or `CITADEL_CONTRACT_WASM` for wasm and `CITADEL_PROVER_PATH` for prover material.
-- CI has an explicit wallet job because the wallet is not a workspace default member. Keep wallet `fmt`, `clippy -p zk-citadel-wallet --all-targets -- -D warnings`, and `make test-wallet` passing.
+- `cargo package -p zk-citadel-wallet --allow-dirty` is expected to fail while
+  the backend-enabled ZK dependencies are pinned only by Git revision. Do not
+  add fallbacks to the incompatible crates.io versions merely to make packaging
+  pass; restore the package check once compatible releases are published.
+- CI has an explicit wallet job because the wallet is not a workspace default member. Keep wallet `fmt`, BLST-featured clippy, and `make test-wallet` passing.
 
 ## Change guidance for agents
 
@@ -126,7 +135,10 @@ Notes:
 - When touching cookies or SP verification, remember that `Session::verify` checks the selected `SessionPolicy`, cookie envelope, session openings, optional exact root, optional exact `attr_data`, and optional attribute opening. Replay/binding, revocation freshness, richer attribute semantics, issuer trust lists beyond the selected key, and rate limits remain SP profile responsibilities.
 - When touching wallet cookie storage or wallet-issued session cookies, remember that `wallet/src/state.rs` stores `citadel_wallet.dat` and `citadel_session_cookies.dat` next to the Rusk wallet using an AES-GCM key derived from the encrypted wallet material. Session cookies remain bearer credentials.
 - When touching wallet contract payload types or metadata validation, keep `wallet/src/citadel.rs`, `contract/src/license_types.rs`, contract metadata constants, and the protocol constants synchronized.
-- Before publishing `zk-citadel-wallet`, check `wallet/Cargo.toml` package metadata, `wallet/README.md`, `cargo package -p zk-citadel-wallet`, and the wallet code-analysis commands.
+- Before publishing `zk-citadel-wallet`, ensure the backend-enabled ZK
+  dependencies have compatible crates.io releases, then check
+  `wallet/Cargo.toml` package metadata, `wallet/README.md`,
+  `cargo package -p zk-citadel-wallet`, and the wallet code-analysis commands.
 - Preserve `#![deny(missing_docs)]` expectations in `core` and keep public APIs documented.
 - Preserve the MPL-2.0 license header style used by existing Rust files when adding new Rust source files.
 - Prefer structured serialization/deserialization APIs already in use (`rkyv`, `dusk-bytes`, canonical `from_bytes`/point checks) over hand-rolled byte parsing. When byte parsing is unavoidable, validate lengths and canonical encodings explicitly.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,47 +82,46 @@ make bench
 make run-wallet
 ```
 
-All Makefile build, test, benchmark, and wallet targets use release mode. The build, wallet, test, and benchmark targets select `bls-backend-blst` unless `BLS_BACKEND` is explicitly overridden for a build or wallet run. ZK targets explicitly enable `std`, so `dusk-plonk/std` remains enabled.
+All Makefile build, test, benchmark, and wallet targets use release mode. Consumer-facing contract builds and wallet runs default to `bls-backend-blst` and accept an explicit `BLS_BACKEND` override. Repository tests and benchmarks hardcode `bls-backend-blst`.
 
 Target details:
 
 ```sh
-make contract                         # builds release artifacts and wasm
-make contract BLS_BACKEND=bls-backend-dusk  # explicitly use the Dusk backend
-make test-contract                    # runs make contract, then contract VM tests
+make contract                         # builds BLST release artifacts and wasm
+make test-contract                    # builds BLST artifacts, then runs contract VM tests
 make test-core                        # core tests with zk enabled
 make test-wallet                      # wallet tests in release mode
 make bench                            # core benchmarks with zk enabled
 make bench BENCH_ARGS=--no-run        # compile benchmarks without running them
-make run-wallet WALLET_ARGS="--help"  # run the wallet in release mode
-make run-wallet BLS_BACKEND=bls-backend-dusk WALLET_ARGS="--help"
+make run-wallet WALLET_ARGS="--help"  # defaults to the BLST backend
 ```
 
 Documentation and wallet analysis checks:
 
 ```sh
-RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --no-default-features --features rkyv-impl,std,zk,contract,bls-backend-blst
-cargo fmt --check
-cargo clippy --release --no-default-features --features rkyv-impl,std,zk,contract,bls-backend-blst -- -D warnings
-cargo clippy -p zk-citadel-wallet --all-targets --no-default-features --features bls-backend-blst -- -D warnings
+RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --features zk,bls-backend-blst
+cargo fmt --all --check
+cargo clippy --release --features zk,bls-backend-blst -- -D warnings
+cargo clippy -p zk-citadel-wallet --all-targets --features bls-backend-blst -- -D warnings
 make test-wallet
 ```
 
 Notes:
 - The core, contract, and wallet Cargo features deliberately do not select a
-  BLS backend by default. Direct Cargo invocations must enable exactly one of
-  `bls-backend-blst` or `bls-backend-dusk`; the Makefile selects BLST by
-  default.
+  BLS backend. Direct Cargo invocations must enable exactly one of
+  `bls-backend-blst` or `bls-backend-dusk`. Makefile contract builds and wallet
+  runs default to BLST and accept an explicit override; tests and benchmarks
+  always use BLST.
 - Always run repository tests with `--release`. The PlonK prover path runs in
   parallel and is much faster in release mode; debug-mode ZK tests can appear to
   hang for a long time.
-- Contract tests include `target/prover`, `target/verifier`, and the wasm artifact, so run `make contract` before `contract` VM tests or use `make test-contract`. The contract crate does not define a `zk` feature; do not pass `--features zk` to `cargo test` from `contract/`.
+- Contract tests include `target/prover`, `target/verifier`, and the wasm artifact, so run `make contract` before `contract` VM tests or use `make test-contract`. Both use BLST. The contract crate does not define a `zk` feature; do not pass `--features zk` to `cargo test` from `contract/`.
 - ZK tests should run in release mode through the Makefile so `std` and the BLST backend are selected explicitly. Avoid adding the slow no-std ZK test path to routine docs or CI unless a specific no-std regression needs investigation.
 - `contract/build.rs` first tries to download the trusted setup from `https://nodes.dusk.network/trusted-setup` and verify its SHA-256 hash. If download fails it generates local setup material and warns that this is unsafe for real use. Do not present fallback-generated keys as deployment-ready.
 - `target/` artifacts are generated and ignored. Do not commit proving/verifier keys or wasm build outputs unless the repository policy changes.
 - The wallet defaults `deploy` to `target/wasm32-unknown-unknown/release/license_contract.wasm` and `use-license` to `target/prover`, relative to the current working directory. Override with `--code` or `CITADEL_CONTRACT_WASM` for wasm and `CITADEL_PROVER_PATH` for prover material.
 - `cargo package -p zk-citadel-wallet --allow-dirty` is expected to fail while
-  the backend-enabled ZK dependencies are pinned only by Git revision. Do not
+  the backend-enabled ZK dependencies are available only through Git tags. Do not
   add fallbacks to the incompatible crates.io versions merely to make packaging
   pass; restore the package check once compatible releases are published.
 - CI has an explicit wallet job because the wallet is not a workspace default member. Keep wallet `fmt`, BLST-featured clippy, and `make test-wallet` passing.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,6 +103,7 @@ Documentation and wallet analysis checks:
 ```sh
 RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --no-default-features --features rkyv-impl,std,zk,contract,bls-backend-blst
 cargo fmt --check
+cargo clippy --release --no-default-features --features rkyv-impl,std,zk,contract,bls-backend-blst -- -D warnings
 cargo clippy -p zk-citadel-wallet --all-targets --no-default-features --features bls-backend-blst -- -D warnings
 make test-wallet
 ```

--- a/Makefile
+++ b/Makefile
@@ -7,41 +7,49 @@ WALLET_PACKAGE ?= zk-citadel-wallet
 
 BENCH_ARGS ?=
 WALLET_ARGS ?=
-BLS_BACKEND ?= bls-backend-blst
-override TEST_BLS_BACKEND := bls-backend-blst
 
-.PHONY: help contract test-contract test-core test-wallet bench run-wallet
+.PHONY: help require-bls-backend contract test-contract test-core test-wallet bench run-wallet
 
 help:
 	@printf '%s\n' \
 		'Available targets:' \
-		'  make contract       Build release contract artifacts and wasm' \
+		'  make contract       Build release contract artifacts with BLST' \
 		'  make test-contract  Build contract artifacts and run contract tests' \
 		'  make test-core      Run release core tests with zk enabled' \
 		'  make test-wallet    Run release wallet tests' \
 		'  make bench          Run core benchmarks with zk enabled' \
-		'  make run-wallet     Build and run the Citadel wallet in release mode' \
+		'  make run-wallet     Build and run the Citadel wallet with BLST' \
 		'' \
-		'Build and run targets default to BLS_BACKEND=bls-backend-blst.' \
+		'Contract builds and wallet runs default to BLS_BACKEND=bls-backend-blst.' \
 		'Tests and benchmarks always use bls-backend-blst.'
 
-contract:
-	$(CARGO) build -p license-contract --release --no-default-features --features contract,$(BLS_BACKEND)
+require-bls-backend:
+	@if [ "$(BLS_BACKEND)" != "bls-backend-blst" ] && \
+		[ "$(BLS_BACKEND)" != "bls-backend-dusk" ]; then \
+		printf '%s\n' \
+			'Set BLS_BACKEND to bls-backend-blst or bls-backend-dusk.'; \
+		exit 2; \
+	fi
+
+contract: BLS_BACKEND ?= bls-backend-blst
+contract: require-bls-backend
+	$(CARGO) build -p license-contract --release --features $(BLS_BACKEND)
 	$(RUSTUP) target add $(WASM_TARGET)
-	$(CARGO) build --manifest-path contract/Cargo.toml --target $(WASM_TARGET) --release --no-default-features --features contract,$(BLS_BACKEND)
+	$(CARGO) build --manifest-path contract/Cargo.toml --target $(WASM_TARGET) --release --features $(BLS_BACKEND)
 
 test-contract:
-	$(MAKE) contract BLS_BACKEND=$(TEST_BLS_BACKEND)
-	$(CARGO) test --manifest-path contract/Cargo.toml --release --no-default-features --features contract,$(TEST_BLS_BACKEND) --test license_contract
+	$(MAKE) contract BLS_BACKEND=bls-backend-blst
+	$(CARGO) test --manifest-path contract/Cargo.toml --release --features bls-backend-blst --test license_contract
 
 test-core:
-	$(CARGO) test -p $(CORE_PACKAGE) --release --no-default-features --features rkyv-impl,std,zk,$(TEST_BLS_BACKEND)
+	$(CARGO) test -p $(CORE_PACKAGE) --release --features zk,bls-backend-blst
 
 test-wallet:
-	$(CARGO) test -p $(WALLET_PACKAGE) --release --no-default-features --features $(TEST_BLS_BACKEND)
+	$(CARGO) test -p $(WALLET_PACKAGE) --release --features bls-backend-blst
 
 bench:
-	$(CARGO) bench -p $(CORE_PACKAGE) --profile release --no-default-features --features rkyv-impl,std,zk,$(TEST_BLS_BACKEND) $(BENCH_ARGS)
+	$(CARGO) bench -p $(CORE_PACKAGE) --profile release --features zk,bls-backend-blst $(BENCH_ARGS)
 
-run-wallet:
-	$(CARGO) run -p $(WALLET_PACKAGE) --release --no-default-features --features $(BLS_BACKEND) -- $(WALLET_ARGS)
+run-wallet: BLS_BACKEND ?= bls-backend-blst
+run-wallet: require-bls-backend
+	$(CARGO) run -p $(WALLET_PACKAGE) --release --features $(BLS_BACKEND) -- $(WALLET_ARGS)

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,8 @@ WALLET_PACKAGE ?= zk-citadel-wallet
 
 BENCH_ARGS ?=
 WALLET_ARGS ?=
+BLS_BACKEND ?= bls-backend-blst
+override TEST_BLS_BACKEND := bls-backend-blst
 
 .PHONY: help contract test-contract test-core test-wallet bench run-wallet
 
@@ -18,24 +20,28 @@ help:
 		'  make test-core      Run release core tests with zk enabled' \
 		'  make test-wallet    Run release wallet tests' \
 		'  make bench          Run core benchmarks with zk enabled' \
-		'  make run-wallet     Build and run the Citadel wallet in release mode'
+		'  make run-wallet     Build and run the Citadel wallet in release mode' \
+		'' \
+		'Build and run targets default to BLS_BACKEND=bls-backend-blst.' \
+		'Tests and benchmarks always use bls-backend-blst.'
 
 contract:
-	$(CARGO) build --release --features zk
+	$(CARGO) build -p license-contract --release --no-default-features --features contract,$(BLS_BACKEND)
 	$(RUSTUP) target add $(WASM_TARGET)
-	$(CARGO) build --manifest-path contract/Cargo.toml --target $(WASM_TARGET) --release
+	$(CARGO) build --manifest-path contract/Cargo.toml --target $(WASM_TARGET) --release --no-default-features --features contract,$(BLS_BACKEND)
 
-test-contract: contract
-	$(CARGO) test --manifest-path contract/Cargo.toml --release --test license_contract
+test-contract:
+	$(MAKE) contract BLS_BACKEND=$(TEST_BLS_BACKEND)
+	$(CARGO) test --manifest-path contract/Cargo.toml --release --no-default-features --features contract,$(TEST_BLS_BACKEND) --test license_contract
 
 test-core:
-	$(CARGO) test -p $(CORE_PACKAGE) --release --features zk
+	$(CARGO) test -p $(CORE_PACKAGE) --release --no-default-features --features rkyv-impl,std,zk,$(TEST_BLS_BACKEND)
 
 test-wallet:
-	$(CARGO) test -p $(WALLET_PACKAGE) --release
+	$(CARGO) test -p $(WALLET_PACKAGE) --release --no-default-features --features $(TEST_BLS_BACKEND)
 
 bench:
-	$(CARGO) bench -p $(CORE_PACKAGE) --profile release --features zk $(BENCH_ARGS)
+	$(CARGO) bench -p $(CORE_PACKAGE) --profile release --no-default-features --features rkyv-impl,std,zk,$(TEST_BLS_BACKEND) $(BENCH_ARGS)
 
 run-wallet:
-	$(CARGO) run -p $(WALLET_PACKAGE) --release -- $(WALLET_ARGS)
+	$(CARGO) run -p $(WALLET_PACKAGE) --release --no-default-features --features $(BLS_BACKEND) -- $(WALLET_ARGS)

--- a/README.md
+++ b/README.md
@@ -33,11 +33,11 @@ All build, test, benchmark, and wallet targets compile in release mode. The
 core, contract, and wallet expose `bls-backend-dusk` and
 `bls-backend-blst`, forwarding the final consumer's backend choice through the
 ZK dependency stack. Neither backend is enabled by the Cargo defaults, so a
-consumer must enable exactly one. Makefile build and wallet targets select the
-BLST backend by default and accept `BLS_BACKEND=bls-backend-dusk`; repository
-tests and benchmarks always select BLST. ZK targets explicitly enable `std`, so
-`dusk-plonk/std` remains enabled and PlonK can use its parallel `std`/rayon
-path.
+consumer must enable exactly one. The non-backend Cargo defaults only enable
+general crate functionality such as `std`, serialization support, or the
+contract interface. The `make contract` and `make run-wallet` targets default
+to BLST and accept an explicit `BLS_BACKEND` override. Repository tests,
+benchmarks, documentation, and CI always select BLST.
 
 ### Build Contract
 
@@ -49,11 +49,8 @@ Builds the release contract artifacts, ensures the `wasm32-unknown-unknown`
 target is installed, and compiles the contract wasm as described in
 [`contract/README.md`](contract/README.md).
 
-To build with the Dusk backend instead of the default BLST backend:
-
-```sh
-make contract BLS_BACKEND=bls-backend-dusk
-```
+Consumers that choose the alternative backend can set `BLS_BACKEND`
+explicitly. Repository examples use BLST consistently.
 
 ### Test Contract
 
@@ -106,8 +103,7 @@ Builds and runs the Citadel wallet. Pass CLI arguments with `WALLET_ARGS`:
 make run-wallet WALLET_ARGS="--help"
 ```
 
-Select the Dusk backend for a wallet run with
-`make run-wallet BLS_BACKEND=bls-backend-dusk`.
+Both commands use BLST unless `BLS_BACKEND` is set explicitly.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -29,8 +29,13 @@ This repository is structured as follows:
 Use the Rust toolchain from [`rust-toolchain.toml`](rust-toolchain.toml). The root
 [`Makefile`](Makefile) is the preferred entry point for local and CI workflows.
 
-All build, test, benchmark, and wallet targets compile in release mode. The ZK
-targets keep Cargo default features enabled while adding `zk`, so
+All build, test, benchmark, and wallet targets compile in release mode. The
+core, contract, and wallet expose `bls-backend-dusk` and
+`bls-backend-blst`, forwarding the final consumer's backend choice through the
+ZK dependency stack. Neither backend is enabled by the Cargo defaults, so a
+consumer must enable exactly one. Makefile build and wallet targets select the
+BLST backend by default and accept `BLS_BACKEND=bls-backend-dusk`; repository
+tests and benchmarks always select BLST. ZK targets explicitly enable `std`, so
 `dusk-plonk/std` remains enabled and PlonK can use its parallel `std`/rayon
 path.
 
@@ -43,6 +48,12 @@ make contract
 Builds the release contract artifacts, ensures the `wasm32-unknown-unknown`
 target is installed, and compiles the contract wasm as described in
 [`contract/README.md`](contract/README.md).
+
+To build with the Dusk backend instead of the default BLST backend:
+
+```sh
+make contract BLS_BACKEND=bls-backend-dusk
+```
 
 ### Test Contract
 
@@ -59,6 +70,7 @@ make test-core
 ```
 
 Runs the core test suite in release mode with `zk` enabled.
+Tests always use the BLST backend.
 
 ### Benchmarks
 
@@ -80,6 +92,7 @@ make test-wallet
 ```
 
 Runs the wallet test suite in release mode.
+Tests always use the BLST backend.
 
 ### Run Wallet
 
@@ -92,6 +105,9 @@ Builds and runs the Citadel wallet. Pass CLI arguments with `WALLET_ARGS`:
 ```sh
 make run-wallet WALLET_ARGS="--help"
 ```
+
+Select the Dusk backend for a wallet run with
+`make run-wallet BLS_BACKEND=bls-backend-dusk`.
 
 ## License
 

--- a/contract/Cargo.toml
+++ b/contract/Cargo.toml
@@ -11,10 +11,10 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 dusk-curves = { version = "=0.2.1", default-features = false, features = ["rkyv-impl"] }
 dusk-jubjub = { version = "=0.15.2", default-features = false }
-dusk-poseidon = { git = "https://github.com/dusk-network/zk-tools", rev = "560f2092f1464bd6e2f31fb3f3894eeda7b8f627", default-features = false }
+dusk-poseidon = { git = "https://github.com/dusk-network/zk-tools", tag = "v0.1.0", default-features = false }
 rkyv = { version = "=0.7.39", default-features = false, features = ["size_32"] }
 bytecheck = { version = "=0.6.12", default-features = false }
-poseidon-merkle = { git = "https://github.com/dusk-network/zk-tools", rev = "560f2092f1464bd6e2f31fb3f3894eeda7b8f627", default-features = false, features = ["rkyv-impl"] }
+poseidon-merkle = { git = "https://github.com/dusk-network/zk-tools", tag = "v0.1.0", default-features = false, features = ["rkyv-impl"] }
 
 [target.'cfg(target_family = "wasm")'.dependencies]
 dusk-core = { version = "=1.6.0", features = ["abi-dlmalloc"] }
@@ -42,7 +42,7 @@ bls-backend-blst = [
 
 [build-dependencies]
 zk-citadel = { path = "../core", default-features = false, features = ["rkyv-impl", "std", "zk"] }
-dusk-plonk = { git = "https://github.com/dusk-network/zk-tools", rev = "560f2092f1464bd6e2f31fb3f3894eeda7b8f627", default-features = false, features = ["rkyv-impl", "alloc"] }
+dusk-plonk = { git = "https://github.com/dusk-network/zk-tools", tag = "v0.1.0", default-features = false, features = ["rkyv-impl", "alloc"] }
 rand_core = { version = "0.6", default-features = false, features = ["getrandom"] }
 reqwest = "0.12"
 tokio = { version = "1.41.1", features = ["macros", "rt-multi-thread"] }
@@ -51,10 +51,10 @@ sha2 = { version = "0.10.8", default-features = false }
 
 [dev-dependencies]
 zk-citadel = { path = "../core", default-features = false, features = ["rkyv-impl", "std", "zk"] }
-dusk-plonk = { git = "https://github.com/dusk-network/zk-tools", rev = "560f2092f1464bd6e2f31fb3f3894eeda7b8f627", default-features = false, features = ["rkyv-impl", "alloc", "std"] }
+dusk-plonk = { git = "https://github.com/dusk-network/zk-tools", tag = "v0.1.0", default-features = false, features = ["rkyv-impl", "alloc", "std"] }
 ff = { version = "=0.13.0", default-features = false }
 rand = { version = "0.8.6", default-features = false }
-dusk-poseidon = { git = "https://github.com/dusk-network/zk-tools", rev = "560f2092f1464bd6e2f31fb3f3894eeda7b8f627", default-features = false }
+dusk-poseidon = { git = "https://github.com/dusk-network/zk-tools", tag = "v0.1.0", default-features = false }
 dusk-bytes = "=0.1.7"
 dusk-vm = "=1.6.0"
 dusk-core = { version = "=1.6.0", features = ["zk"] }

--- a/contract/Cargo.toml
+++ b/contract/Cargo.toml
@@ -22,6 +22,7 @@ dusk-forge = "0.3"
 dusk-data-driver = { version = "0.3", default-features = false, features = ["alloc", "wasm-export"], optional = true }
 
 [features]
+# The final consumer must select exactly one BLS backend.
 default = ["contract"]
 contract = []
 data-driver = ["dep:dusk-data-driver"]

--- a/contract/Cargo.toml
+++ b/contract/Cargo.toml
@@ -9,12 +9,12 @@ publish = false
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-dusk-bls12_381 = { version = "=0.14.2", default-features = false }
+dusk-curves = { version = "=0.2.1", default-features = false, features = ["rkyv-impl"] }
 dusk-jubjub = { version = "=0.15.2", default-features = false }
-dusk-poseidon = { version = "=0.42.0-rc.0", default-features = false }
+dusk-poseidon = { git = "https://github.com/dusk-network/zk-tools", rev = "560f2092f1464bd6e2f31fb3f3894eeda7b8f627", default-features = false }
 rkyv = { version = "=0.7.39", default-features = false, features = ["size_32"] }
 bytecheck = { version = "=0.6.12", default-features = false }
-poseidon-merkle = { version = "=0.9.0-rc.0", features = ["rkyv-impl"] }
+poseidon-merkle = { git = "https://github.com/dusk-network/zk-tools", rev = "560f2092f1464bd6e2f31fb3f3894eeda7b8f627", default-features = false, features = ["rkyv-impl"] }
 
 [target.'cfg(target_family = "wasm")'.dependencies]
 dusk-core = { version = "=1.6.0", features = ["abi-dlmalloc"] }
@@ -25,10 +25,24 @@ dusk-data-driver = { version = "0.3", default-features = false, features = ["all
 default = ["contract"]
 contract = []
 data-driver = ["dep:dusk-data-driver"]
+bls-backend-dusk = [
+    "dusk-curves/bls-backend-dusk",
+    "dusk-plonk/bls-backend-dusk",
+    "dusk-poseidon/bls-backend-dusk",
+    "poseidon-merkle/bls-backend-dusk",
+    "zk-citadel/bls-backend-dusk",
+]
+bls-backend-blst = [
+    "dusk-curves/bls-backend-blst",
+    "dusk-plonk/bls-backend-blst",
+    "dusk-poseidon/bls-backend-blst",
+    "poseidon-merkle/bls-backend-blst",
+    "zk-citadel/bls-backend-blst",
+]
 
 [build-dependencies]
-zk-citadel = { path = "../core", features = ["zk"] }
-dusk-plonk = { version = "0.22", default-features = false, features = ["rkyv-impl", "alloc"] }
+zk-citadel = { path = "../core", default-features = false, features = ["rkyv-impl", "std", "zk"] }
+dusk-plonk = { git = "https://github.com/dusk-network/zk-tools", rev = "560f2092f1464bd6e2f31fb3f3894eeda7b8f627", default-features = false, features = ["rkyv-impl", "alloc"] }
 rand_core = { version = "0.6", default-features = false, features = ["getrandom"] }
 reqwest = "0.12"
 tokio = { version = "1.41.1", features = ["macros", "rt-multi-thread"] }
@@ -36,10 +50,11 @@ build-print = "0.1.1"
 sha2 = { version = "0.10.8", default-features = false }
 
 [dev-dependencies]
-zk-citadel = { path = "../core", features = ["zk"] }
+zk-citadel = { path = "../core", default-features = false, features = ["rkyv-impl", "std", "zk"] }
+dusk-plonk = { git = "https://github.com/dusk-network/zk-tools", rev = "560f2092f1464bd6e2f31fb3f3894eeda7b8f627", default-features = false, features = ["rkyv-impl", "alloc", "std"] }
 ff = { version = "=0.13.0", default-features = false }
 rand = { version = "0.8.6", default-features = false }
-dusk-poseidon = "=0.42.0-rc.0"
+dusk-poseidon = { git = "https://github.com/dusk-network/zk-tools", rev = "560f2092f1464bd6e2f31fb3f3894eeda7b8f627", default-features = false }
 dusk-bytes = "=0.1.7"
 dusk-vm = "=1.6.0"
 dusk-core = { version = "=1.6.0", features = ["zk"] }

--- a/contract/README.md
+++ b/contract/README.md
@@ -20,8 +20,8 @@ The equivalent direct Cargo commands must select a backend explicitly. To
 generate the circuit artifacts and build the native contract with BLST:
 
 ```sh
-cargo build -p license-contract --release --no-default-features \
-  --features contract,bls-backend-blst
+cargo build -p license-contract --release \
+  --features bls-backend-blst
 ```
 
 Then compile the wasm contract and run the VM tests:
@@ -29,13 +29,14 @@ Then compile the wasm contract and run the VM tests:
 ```sh
 rustup target add wasm32-unknown-unknown
 cargo build -p license-contract --target wasm32-unknown-unknown --release \
-  --no-default-features \
-  --features contract,bls-backend-blst
-cargo test -p license-contract --release --no-default-features \
-  --features contract,bls-backend-blst --test license_contract
+  --features bls-backend-blst
+cargo test -p license-contract --release \
+  --features bls-backend-blst --test license_contract
 ```
 
-Use `bls-backend-dusk` instead when explicitly selecting the Dusk backend.
+The contract's default `contract` feature does not select a BLS backend. Final
+consumers can choose the alternative backend explicitly; repository examples,
+tests, and CI use BLST.
 
 The build script first tries to download the Dusk trusted setup and verify its SHA-256 hash. If the download is unavailable it generates local setup material so tests can run, but those generated keys are not deployment-ready.
 

--- a/contract/README.md
+++ b/contract/README.md
@@ -9,23 +9,33 @@ This package contains the Citadel contract. It stores encrypted licenses and lic
 
 ## Usage
 
-First, compile the license circuit (`/target/prover` and `/target/verifier`) as follows:
+From the repository root, the preferred BLST build and test commands are:
 
-```
-cargo build --release
-```
-
-Then, compile the license contract:
-
-```
-cargo build --target wasm32-unknown-unknown --release
+```sh
+make contract
+make test-contract
 ```
 
-Finally, execute the tests:
+The equivalent direct Cargo commands must select a backend explicitly. To
+generate the circuit artifacts and build the native contract with BLST:
 
+```sh
+cargo build -p license-contract --release --no-default-features \
+  --features contract,bls-backend-blst
 ```
-cargo test --release --test license_contract
+
+Then compile the wasm contract and run the VM tests:
+
+```sh
+rustup target add wasm32-unknown-unknown
+cargo build -p license-contract --target wasm32-unknown-unknown --release \
+  --no-default-features \
+  --features contract,bls-backend-blst
+cargo test -p license-contract --release --no-default-features \
+  --features contract,bls-backend-blst --test license_contract
 ```
+
+Use `bls-backend-dusk` instead when explicitly selecting the Dusk backend.
 
 The build script first tries to download the Dusk trusted setup and verify its SHA-256 hash. If the download is unavailable it generates local setup material so tests can run, but those generated keys are not deployment-ready.
 

--- a/contract/src/license_types.rs
+++ b/contract/src/license_types.rs
@@ -9,7 +9,7 @@ use alloc::vec::Vec;
 use bytecheck::CheckBytes;
 use rkyv::{Archive, Deserialize, Serialize};
 
-use dusk_bls12_381::BlsScalar;
+use dusk_curves::bls12_381::BlsScalar;
 
 /// Maximum encrypted license blob size accepted by the contract.
 pub const MAX_LICENSE_BLOB_SIZE: usize = 4096;

--- a/contract/src/state.rs
+++ b/contract/src/state.rs
@@ -10,8 +10,8 @@ pub mod license_contract {
 
     use alloc::vec::Vec;
 
-    use dusk_bls12_381::BlsScalar;
     use dusk_core::abi::{block_height, feed, verify_plonk};
+    use dusk_curves::bls12_381::BlsScalar;
     use dusk_jubjub::JubJubAffine;
     use dusk_poseidon::{Domain, Hash};
     use license_contract::{

--- a/contract/tests/license_contract.rs
+++ b/contract/tests/license_contract.rs
@@ -27,9 +27,9 @@ pub type LicenseOpening = poseidon_merkle::Opening<(), { circuit::DEPTH }>;
 use dusk_core::{
     BlsScalar, JubJubAffine, JubJubScalar,
     abi::ContractId,
-    plonk::{Prover, Verifier},
     transfer::phoenix::{PublicKey, SecretKey, ViewKey},
 };
+use dusk_plonk::prelude::{Prover, Verifier};
 use dusk_vm::{ContractData, Session, VM};
 
 #[path = "../src/license_types.rs"]

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -11,7 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Use the `zk-tools` Git workspace for the PlonK, Poseidon, and Poseidon Merkle
   crates, expose consumer-selected Dusk/BLST BLS backends, and use
-  `dusk-curves` for direct BLS scalar access.
+  `dusk-curves` for direct BLS scalar access. Repository tests and benchmarks
+  select BLST explicitly.
 
 ## [0.15.0] - 2026-05-31
 

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Use the `zk-tools` Git workspace for the PlonK, Poseidon, and Poseidon Merkle
+  crates, expose consumer-selected Dusk/BLST BLS backends, and use
+  `dusk-curves` for direct BLS scalar access.
+
 ## [0.15.0] - 2026-05-31
 
 ### Added

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -11,9 +11,9 @@ license = "MPL-2.0"
 
 [dependencies]
 dusk-bytes = "0.1"
-dusk-poseidon = { git = "https://github.com/dusk-network/zk-tools", rev = "560f2092f1464bd6e2f31fb3f3894eeda7b8f627", default-features = false }
-poseidon-merkle = { git = "https://github.com/dusk-network/zk-tools", rev = "560f2092f1464bd6e2f31fb3f3894eeda7b8f627", default-features = false, features = ["rkyv-impl", "size_32"], optional = true }
-dusk-plonk = { git = "https://github.com/dusk-network/zk-tools", rev = "560f2092f1464bd6e2f31fb3f3894eeda7b8f627", default-features = false, features = ["rkyv-impl", "alloc"] }
+dusk-poseidon = { git = "https://github.com/dusk-network/zk-tools", tag = "v0.1.0", default-features = false }
+poseidon-merkle = { git = "https://github.com/dusk-network/zk-tools", tag = "v0.1.0", default-features = false, features = ["rkyv-impl", "size_32"], optional = true }
+dusk-plonk = { git = "https://github.com/dusk-network/zk-tools", tag = "v0.1.0", default-features = false, features = ["rkyv-impl", "alloc"] }
 dusk-curves = { version = "=0.2.1", default-features = false, features = ["rkyv-impl"] }
 dusk-jubjub = { version = "0.15", default-features = false, features = ["rkyv-impl", "alloc"] }
 ff = { version = "0.13", default-features = false }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -11,13 +11,12 @@ license = "MPL-2.0"
 
 [dependencies]
 dusk-bytes = "0.1"
-dusk-poseidon = "0.42.0-rc.0"
-poseidon-merkle = { version = "0.9.0-rc.0", features = ["rkyv-impl", "size_32"], optional = true }
-dusk-plonk = { version = "0.22", default-features = false, features = ["rkyv-impl", "alloc"] }
-dusk-bls12_381 = { version = "0.14", default-features = false, features = ["rkyv-impl", "alloc"] }
+dusk-poseidon = { git = "https://github.com/dusk-network/zk-tools", rev = "560f2092f1464bd6e2f31fb3f3894eeda7b8f627", default-features = false }
+poseidon-merkle = { git = "https://github.com/dusk-network/zk-tools", rev = "560f2092f1464bd6e2f31fb3f3894eeda7b8f627", default-features = false, features = ["rkyv-impl", "size_32"], optional = true }
+dusk-plonk = { git = "https://github.com/dusk-network/zk-tools", rev = "560f2092f1464bd6e2f31fb3f3894eeda7b8f627", default-features = false, features = ["rkyv-impl", "alloc"] }
+dusk-curves = { version = "=0.2.1", default-features = false, features = ["rkyv-impl"] }
 dusk-jubjub = { version = "0.15", default-features = false, features = ["rkyv-impl", "alloc"] }
 ff = { version = "0.13", default-features = false }
-jubjub-schnorr = { version = "0.7.0-rc.0", features = ["rkyv-impl", "alloc"] }
 phoenix-core = { version = "0.35", features = ["rkyv-impl", "alloc"] }
 rand_core = { version = "0.6", default-features = false }
 rkyv = { version = "0.7", default-features = false, features = ["size_32"] }
@@ -35,5 +34,17 @@ required-features = ["zk"]
 [features]
 rkyv-impl = []
 std = ["dusk-plonk/std"]
-zk = ["dep:poseidon-merkle", "dusk-poseidon/zk", "jubjub-schnorr/zk", "poseidon-merkle/zk"]
+zk = ["dep:poseidon-merkle", "dusk-poseidon/zk", "poseidon-merkle/zk"]
+bls-backend-dusk = [
+    "dusk-curves/bls-backend-dusk",
+    "dusk-plonk/bls-backend-dusk",
+    "dusk-poseidon/bls-backend-dusk",
+    "poseidon-merkle?/bls-backend-dusk",
+]
+bls-backend-blst = [
+    "dusk-curves/bls-backend-blst",
+    "dusk-plonk/bls-backend-blst",
+    "dusk-poseidon/bls-backend-blst",
+    "poseidon-merkle?/bls-backend-blst",
+]
 default = ["rkyv-impl", "std"]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -29,7 +29,7 @@ rand_core = { version = "0.6", default-features = false, features = ["getrandom"
 [[bench]]
 name = "license_circuit"
 harness = false
-required-features = ["zk"]
+required-features = ["zk", "bls-backend-blst"]
 
 [features]
 rkyv-impl = []
@@ -47,4 +47,5 @@ bls-backend-blst = [
     "dusk-poseidon/bls-backend-blst",
     "poseidon-merkle?/bls-backend-blst",
 ]
+# The final consumer must select exactly one BLS backend.
 default = ["rkyv-impl", "std"]

--- a/core/README.md
+++ b/core/README.md
@@ -11,18 +11,19 @@ This package contains the off-chain Citadel protocol API: encrypted request and 
 ## Tests
 
 The crate exposes `bls-backend-blst` and `bls-backend-dusk`; consumers must
-enable exactly one. Repository tests use BLST:
+enable exactly one. Its Cargo defaults enable `rkyv-impl` and `std`, but
+deliberately do not select a BLS backend. Repository tests use BLST:
 
 ```sh
-cargo test -p zk-citadel --release --no-default-features \
-  --features rkyv-impl,std,zk,bls-backend-blst
+cargo test -p zk-citadel --release \
+  --features zk,bls-backend-blst
 ```
 
 Documentation can be checked by running:
 
 ```sh
-cargo doc -p zk-citadel --no-deps --no-default-features \
-  --features rkyv-impl,std,zk,bls-backend-blst
+cargo doc -p zk-citadel --no-deps \
+  --features zk,bls-backend-blst
 ```
 
 ## Benchmarks
@@ -30,8 +31,8 @@ cargo doc -p zk-citadel --no-deps --no-default-features \
 The package can be benchmarked by running:
 
 ```sh
-cargo bench -p zk-citadel --profile release --no-default-features \
-  --features rkyv-impl,std,zk,bls-backend-blst
+cargo bench -p zk-citadel --profile release \
+  --features zk,bls-backend-blst
 ```
 
 ## License

--- a/core/README.md
+++ b/core/README.md
@@ -10,24 +10,28 @@ This package contains the off-chain Citadel protocol API: encrypted request and 
 
 ## Tests
 
-The package can be tested by running:
+The crate exposes `bls-backend-blst` and `bls-backend-dusk`; consumers must
+enable exactly one. Repository tests use BLST:
 
-```
-cargo test --release --features zk
+```sh
+cargo test -p zk-citadel --release --no-default-features \
+  --features rkyv-impl,std,zk,bls-backend-blst
 ```
 
 Documentation can be checked by running:
 
-```
-cargo doc --no-deps --features zk
+```sh
+cargo doc -p zk-citadel --no-deps --no-default-features \
+  --features rkyv-impl,std,zk,bls-backend-blst
 ```
 
 ## Benchmarks
 
 The package can be benchmarked by running:
 
-```
-cargo bench --features zk
+```sh
+cargo bench -p zk-citadel --profile release --no-default-features \
+  --features rkyv-impl,std,zk,bls-backend-blst
 ```
 
 ## License

--- a/core/src/zk/gadgets.rs
+++ b/core/src/zk/gadgets.rs
@@ -4,9 +4,7 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use dusk_jubjub::{
-    EDWARDS_D, GENERATOR, GENERATOR_EXTENDED, GENERATOR_NUMS, GENERATOR_NUMS_EXTENDED, dhke,
-};
+use dusk_jubjub::{GENERATOR, GENERATOR_EXTENDED, GENERATOR_NUMS, GENERATOR_NUMS_EXTENDED, dhke};
 use dusk_plonk::prelude::*;
 use dusk_poseidon::{Domain, HashGadget};
 use ff::Field;
@@ -52,8 +50,8 @@ pub fn use_license<const DEPTH: usize>(
     // APPEND THE LICENSE PUBLIC KEYS OF THE USER
     let lpk = composer.append_point(gp.lpk);
     let lpk_p = composer.append_point(gp.lpk_p);
-    assert_valid_witness_point(composer, lpk);
-    assert_valid_witness_point(composer, lpk_p);
+    let lpk = assert_valid_witness_point(composer, lpk);
+    let lpk_p = assert_valid_witness_point(composer, lpk_p);
 
     // APPEND PUBLIC INPUTS IN THE SPECIFIED ORDER
     let c = composer.append_witness(sc.c);
@@ -77,10 +75,10 @@ pub fn use_license<const DEPTH: usize>(
     // VERIFY THE LICENSE SIGNATURE
     let sig_lic_z = composer.append_witness(*gp.sig_lic.z());
     let sig_lic_r = composer.append_point(gp.sig_lic.R());
-    assert_valid_witness_point(composer, sig_lic_r);
+    let sig_lic_r = assert_valid_witness_point(composer, sig_lic_r);
     let pk_lp_a = JubJubAffine::from(sc.pk_lp.A());
     let pk_lp = composer.append_point(pk_lp_a);
-    assert_valid_witness_point(composer, pk_lp);
+    let pk_lp = assert_valid_witness_point(composer, pk_lp);
     let attr_data = composer.append_witness(sc.attr_data);
 
     let license_sig_ctx =
@@ -112,7 +110,7 @@ pub fn use_license<const DEPTH: usize>(
     let pc_1_2 = composer.component_mul_generator(s_1, GENERATOR_NUMS)?;
     let com_1 = composer.component_add_point(pc_1_1, pc_1_2);
 
-    composer.assert_equal_point(com_1, com_1_pi);
+    composer.assert_equal_point(com_1.into(), com_1_pi);
 
     // COMMIT TO THE CHALLENGE
     let s_2 = composer.append_witness(sc.s_2);
@@ -120,7 +118,7 @@ pub fn use_license<const DEPTH: usize>(
     let pc_2_2 = composer.component_mul_generator(s_2, GENERATOR_NUMS)?;
     let com_2 = composer.component_add_point(pc_2_1, pc_2_2);
 
-    composer.assert_equal_point(com_2, com_2_pi);
+    composer.assert_equal_point(com_2.into(), com_2_pi);
 
     // VERIFY THE SESSION AUTHORIZATION SIGNATURE
     let session_auth_ctx = composer.append_constant(deployment.context(CitadelDomain::SessionAuth));
@@ -143,8 +141,8 @@ pub fn use_license<const DEPTH: usize>(
     let sig_session_auth_z = composer.append_witness(*gp.sig_session_auth.z());
     let sig_session_auth_r = composer.append_point(gp.sig_session_auth.R());
     let sig_session_auth_r_p = composer.append_point(gp.sig_session_auth.R_prime());
-    assert_valid_witness_point(composer, sig_session_auth_r);
-    assert_valid_witness_point(composer, sig_session_auth_r_p);
+    let sig_session_auth_r = assert_valid_witness_point(composer, sig_session_auth_r);
+    let sig_session_auth_r_p = assert_valid_witness_point(composer, sig_session_auth_r_p);
 
     verify_session_auth_signature(
         composer,
@@ -178,8 +176,8 @@ fn verify_license_signature(
     composer: &mut Composer,
     deployment: crate::helpers::Deployment,
     z: Witness,
-    r: WitnessPoint,
-    pk: WitnessPoint,
+    r: TorsionFreeWitnessPoint,
+    pk: TorsionFreeWitnessPoint,
     msg: Witness,
 ) -> Result<(), Error> {
     let ctx = composer.append_constant(deployment.context(CitadelDomain::LicenseSigChallenge));
@@ -192,17 +190,17 @@ fn verify_license_signature(
     let lhs = composer.component_mul_generator(z, GENERATOR)?;
     let challenge_pk = composer.component_mul_point(challenge, pk);
     let rhs = composer.component_add_point(r, challenge_pk);
-    composer.assert_equal_point(lhs, rhs);
+    composer.assert_equal_point(lhs.into(), rhs.into());
 
     Ok(())
 }
 
 struct SessionAuthWitnesses {
     z: Witness,
-    r: WitnessPoint,
-    r_p: WitnessPoint,
-    pk: WitnessPoint,
-    pk_p: WitnessPoint,
+    r: TorsionFreeWitnessPoint,
+    r_p: TorsionFreeWitnessPoint,
+    pk: TorsionFreeWitnessPoint,
+    pk_p: TorsionFreeWitnessPoint,
     msg: Witness,
 }
 
@@ -232,45 +230,22 @@ fn verify_session_auth_signature(
     let lhs = composer.component_mul_generator(witnesses.z, GENERATOR)?;
     let challenge_pk = composer.component_mul_point(challenge, witnesses.pk);
     let rhs = composer.component_add_point(witnesses.r, challenge_pk);
-    composer.assert_equal_point(lhs, rhs);
+    composer.assert_equal_point(lhs.into(), rhs.into());
 
     let lhs_prime = composer.component_mul_generator(witnesses.z, GENERATOR_NUMS)?;
     let challenge_pk_prime = composer.component_mul_point(challenge, witnesses.pk_p);
     let rhs_prime = composer.component_add_point(witnesses.r_p, challenge_pk_prime);
-    composer.assert_equal_point(lhs_prime, rhs_prime);
+    composer.assert_equal_point(lhs_prime.into(), rhs_prime.into());
 
     Ok(())
 }
 
-fn assert_valid_witness_point(composer: &mut Composer, point: WitnessPoint) {
-    assert_on_curve(composer, point);
+fn assert_valid_witness_point(
+    composer: &mut Composer,
+    point: WitnessPoint,
+) -> TorsionFreeWitnessPoint {
     assert_not_identity(composer, point);
-
-    // Jubjub has cofactor 8; multiplying by 8 must not collapse a valid
-    // prime-order witness point to the identity.
-    let two_p = composer.component_add_point(point, point);
-    let four_p = composer.component_add_point(two_p, two_p);
-    let eight_p = composer.component_add_point(four_p, four_p);
-    assert_not_identity(composer, eight_p);
-}
-
-fn assert_on_curve(composer: &mut Composer, point: WitnessPoint) {
-    let x = *point.x();
-    let y = *point.y();
-    let x2 = composer.gate_mul(Constraint::new().mult(1).a(x).b(x));
-    let y2 = composer.gate_mul(Constraint::new().mult(1).a(y).b(y));
-    let x2_y2 = composer.gate_mul(Constraint::new().mult(1).a(x2).b(y2));
-    let curve = composer.gate_add(
-        Constraint::new()
-            .left(1)
-            .right(-BlsScalar::one())
-            .fourth(-EDWARDS_D)
-            .constant(-BlsScalar::one())
-            .a(y2)
-            .b(x2)
-            .d(x2_y2),
-    );
-    composer.assert_equal_constant(curve, BlsScalar::zero(), None);
+    composer.assert_torsion_free_point(point)
 }
 
 fn assert_not_identity(composer: &mut Composer, point: WitnessPoint) {

--- a/wallet/CHANGELOG.md
+++ b/wallet/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Expose consumer-selected Dusk/BLST BLS backends without a default backend;
+  repository examples, tests, and CI select BLST explicitly.
 - Change default call gas pricing to use lower Lux gas prices with separate
   gas limits for issuance and license-use calls.
 - Improve TUI input handling by enabling bracketed paste, filtering whitespace

--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -28,11 +28,11 @@ crossterm = "0.29"
 dusk-curves = { version = "=0.2.1", default-features = false, features = ["rkyv-impl"] }
 dusk-bytes = "0.1"
 dusk-core = "1.6.0"
-dusk-plonk = { git = "https://github.com/dusk-network/zk-tools", rev = "560f2092f1464bd6e2f31fb3f3894eeda7b8f627", default-features = false, features = ["alloc", "std", "rkyv-impl"] }
+dusk-plonk = { git = "https://github.com/dusk-network/zk-tools", tag = "v0.1.0", default-features = false, features = ["alloc", "std", "rkyv-impl"] }
 dusk-jubjub = "0.15"
 hex = "0.4"
 phoenix-core = { version = "0.35", features = ["rkyv-impl"] }
-poseidon-merkle = { git = "https://github.com/dusk-network/zk-tools", rev = "560f2092f1464bd6e2f31fb3f3894eeda7b8f627", default-features = false, features = ["rkyv-impl", "size_32"] }
+poseidon-merkle = { git = "https://github.com/dusk-network/zk-tools", tag = "v0.1.0", default-features = false, features = ["rkyv-impl", "size_32"] }
 pbkdf2 = "0.12"
 rand = "0.8"
 ratatui = "0.30"

--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -25,14 +25,14 @@ bytecheck = "0.6"
 chrono = "0.4"
 clap = { version = "4.5", features = ["derive", "env"] }
 crossterm = "0.29"
-dusk-bls12_381 = { version = "=0.14.2", features = ["rkyv-impl"] }
+dusk-curves = { version = "=0.2.1", default-features = false, features = ["rkyv-impl"] }
 dusk-bytes = "0.1"
 dusk-core = "1.6.0"
-dusk-plonk = { version = "0.22", default-features = false, features = ["alloc", "std", "rkyv-impl"] }
+dusk-plonk = { git = "https://github.com/dusk-network/zk-tools", rev = "560f2092f1464bd6e2f31fb3f3894eeda7b8f627", default-features = false, features = ["alloc", "std", "rkyv-impl"] }
 dusk-jubjub = "0.15"
 hex = "0.4"
 phoenix-core = { version = "0.35", features = ["rkyv-impl"] }
-poseidon-merkle = { version = "0.9.0-rc.0", features = ["rkyv-impl", "size_32"] }
+poseidon-merkle = { git = "https://github.com/dusk-network/zk-tools", rev = "560f2092f1464bd6e2f31fb3f3894eeda7b8f627", default-features = false, features = ["rkyv-impl", "size_32"] }
 pbkdf2 = "0.12"
 rand = "0.8"
 ratatui = "0.30"
@@ -43,5 +43,20 @@ rusk-wallet = "0.3.0"
 sha2 = "0.10"
 tokio = { version = "1.41.1", features = ["macros", "rt-multi-thread"] }
 wallet_core = { package = "dusk-wallet-core", version = "1.6.0" }
-zk-citadel = { version = "0.15.0", path = "../core", features = ["zk", "std"] }
+zk-citadel = { version = "0.15.0", path = "../core", default-features = false, features = ["rkyv-impl", "zk", "std"] }
 zeroize = "1.8"
+
+[features]
+default = []
+bls-backend-dusk = [
+    "dusk-curves/bls-backend-dusk",
+    "dusk-plonk/bls-backend-dusk",
+    "poseidon-merkle/bls-backend-dusk",
+    "zk-citadel/bls-backend-dusk",
+]
+bls-backend-blst = [
+    "dusk-curves/bls-backend-blst",
+    "dusk-plonk/bls-backend-blst",
+    "poseidon-merkle/bls-backend-blst",
+    "zk-citadel/bls-backend-blst",
+]

--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -47,6 +47,7 @@ zk-citadel = { version = "0.15.0", path = "../core", default-features = false, f
 zeroize = "1.8"
 
 [features]
+# The final consumer must select exactly one BLS backend.
 default = []
 bls-backend-dusk = [
     "dusk-curves/bls-backend-dusk",

--- a/wallet/README.md
+++ b/wallet/README.md
@@ -23,7 +23,8 @@ circuit, contract, dependency, and operational review.
 To use the interactive wallet, simply execute:
 
 ```sh
-cargo run --release --features bls-backend-blst
+cargo run -p zk-citadel-wallet --release --no-default-features \
+  --features bls-backend-blst
 ```
 
 Also, you can install the last released version from `crates.io`:
@@ -60,7 +61,8 @@ Session cookies are bearer credentials; handle them as sensitive.
 Run the wallet unit tests:
 
 ```sh
-cargo test --release --no-default-features --features bls-backend-blst
+cargo test -p zk-citadel-wallet --release --no-default-features \
+  --features bls-backend-blst
 ```
 
 ## Non-interactive API

--- a/wallet/README.md
+++ b/wallet/README.md
@@ -23,7 +23,7 @@ circuit, contract, dependency, and operational review.
 To use the interactive wallet, simply execute:
 
 ```sh
-cargo run --release
+cargo run --release --features bls-backend-blst
 ```
 
 Also, you can install the last released version from `crates.io`:
@@ -60,7 +60,7 @@ Session cookies are bearer credentials; handle them as sensitive.
 Run the wallet unit tests:
 
 ```sh
-cargo t --release
+cargo test --release --no-default-features --features bls-backend-blst
 ```
 
 ## Non-interactive API

--- a/wallet/README.md
+++ b/wallet/README.md
@@ -23,14 +23,15 @@ circuit, contract, dependency, and operational review.
 To use the interactive wallet, simply execute:
 
 ```sh
-cargo run -p zk-citadel-wallet --release --no-default-features \
+cargo run -p zk-citadel-wallet --release \
   --features bls-backend-blst
 ```
 
 Also, you can install the last released version from `crates.io`:
 
 ```sh
-cargo install zk-citadel-wallet
+cargo install zk-citadel-wallet \
+  --features bls-backend-blst
 ```
 
 ## Requirements
@@ -40,7 +41,8 @@ cargo install zk-citadel-wallet
 - Point `--state`, `--prover`, and `--archiver` at the intended Rusk services.
   `--prover` and `--archiver` default to `--state`.
 - Build matching Citadel contract artifacts before `deploy` or `use-license`.
-  From the Citadel repository root, run `make contract`.
+  From the Citadel repository root, run `make contract`, which uses BLST by
+  default.
 
 Artifact defaults are relative to the current working directory:
 
@@ -61,7 +63,7 @@ Session cookies are bearer credentials; handle them as sensitive.
 Run the wallet unit tests:
 
 ```sh
-cargo test -p zk-citadel-wallet --release --no-default-features \
+cargo test -p zk-citadel-wallet --release \
   --features bls-backend-blst
 ```
 

--- a/wallet/src/citadel.rs
+++ b/wallet/src/citadel.rs
@@ -14,9 +14,9 @@ use std::{path::Path, str::FromStr};
 
 use anyhow::{Context, Result, anyhow};
 use bytecheck::CheckBytes;
-use dusk_bls12_381::BlsScalar;
 use dusk_bytes::Serializable;
 use dusk_core::{JubJubAffine, JubJubScalar};
+use dusk_curves::bls12_381::BlsScalar;
 use dusk_plonk::prelude::Prover;
 use phoenix_core::{PublicKey, SecretKey};
 use poseidon_merkle::Opening;

--- a/wallet/src/dusk/query.rs
+++ b/wallet/src/dusk/query.rs
@@ -32,7 +32,7 @@ pub struct CitadelQuery {
     pub tree_len: u32,
     pub sessions: u32,
     pub accepted_roots: u32,
-    pub current_root: dusk_bls12_381::BlsScalar,
+    pub current_root: dusk_curves::bls12_381::BlsScalar,
 }
 
 impl Dusk {
@@ -72,7 +72,10 @@ impl Dusk {
         Ok(metadata)
     }
 
-    pub async fn current_root(&self, contract_id: &str) -> Result<dusk_bls12_381::BlsScalar> {
+    pub async fn current_root(
+        &self,
+        contract_id: &str,
+    ) -> Result<dusk_curves::bls12_381::BlsScalar> {
         let contract_id = normalize_contract_id(contract_id)?;
         let request = citadel::serialize_unit()?;
         let response = self
@@ -84,7 +87,7 @@ impl Dusk {
     pub async fn accepted_roots(
         &self,
         contract_id: &str,
-    ) -> Result<Vec<dusk_bls12_381::BlsScalar>> {
+    ) -> Result<Vec<dusk_curves::bls12_381::BlsScalar>> {
         let contract_id = normalize_contract_id(contract_id)?;
         let request = citadel::serialize_unit()?;
         let response = self
@@ -114,7 +117,7 @@ impl Dusk {
     pub async fn session(
         &self,
         contract_id: &str,
-        session_id: dusk_bls12_381::BlsScalar,
+        session_id: dusk_curves::bls12_381::BlsScalar,
     ) -> Result<Option<citadel::LicenseSession>> {
         let contract_id = normalize_contract_id(contract_id)?;
         let request =


### PR DESCRIPTION
This PR switches the BLS dependency to dusk_curves. To do so, we use the zk-tools package, that contains already updated dependencies.